### PR TITLE
주간 환율 카드뉴스 자동 발송 파이프라인 추가

### DIFF
--- a/.github/workflows/fx-newsletter-test.yml
+++ b/.github/workflows/fx-newsletter-test.yml
@@ -1,0 +1,74 @@
+name: 환율 카드뉴스 테스트
+
+on:
+  pull_request:
+    paths:
+      - "tools/**"
+      - ".github/workflows/fx-newsletter*.yml"
+  push:
+    branches: [master]
+    paths:
+      - "tools/**"
+      - ".github/workflows/fx-newsletter*.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fx-newsletter-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: tools
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tools/fx_newsletter/requirements.txt
+
+      # 발송 워크플로와 같은 폰트 환경에서 렌더링을 검증한다.
+      - name: 한글 폰트 설치
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq fonts-nanum
+          fc-cache -f
+
+      - name: 의존성 설치
+        run: pip install -r fx_newsletter/requirements.txt
+
+      - name: 테스트
+        run: python -m unittest discover -s fx_newsletter/tests -t . -v
+
+      # 실제 발송 경로를 뺀 나머지를 합성 데이터 없이 한 번 더 훑는다.
+      - name: 카드 렌더링 스모크 테스트
+        run: |
+          python - <<'PY'
+          import datetime as dt
+          from pathlib import Path
+          from fx_newsletter import cards, commentary, fetch, indicators
+          from fx_newsletter.tests.fixtures import synthetic_payload
+
+          end = dt.date(2026, 9, 4)
+          snapshots = indicators.build_snapshots(fetch.to_series(synthetic_payload(end)))
+          note = commentary.rule_based(snapshots)
+          paths = cards.render_all(snapshots, note, end, Path("build/smoke"))
+          print(f"카드 {len(paths)}장 생성 완료")
+          PY
+
+      - name: 스모크 결과 보관
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-cards-${{ github.run_number }}
+          path: tools/build/smoke
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/fx-newsletter.yml
+++ b/.github/workflows/fx-newsletter.yml
@@ -1,0 +1,73 @@
+name: 주간 환율 카드뉴스
+
+on:
+  schedule:
+    # UTC 기준. 일요일 23:00 UTC = 월요일 08:00 KST.
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "메일을 보내지 않고 카드만 만든다"
+        type: boolean
+        default: false
+      no_ai:
+        description: "Claude 해설을 건너뛰고 규칙 기반 문장만 쓴다"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fx-newsletter
+  cancel-in-progress: false
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: tools
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tools/fx_newsletter/requirements.txt
+
+      - name: 한글 폰트 설치
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq fonts-nanum
+          fc-cache -f
+
+      - name: 의존성 설치
+        run: pip install -r fx_newsletter/requirements.txt
+
+      - name: 테스트
+        run: python -m unittest discover -s fx_newsletter/tests -t .
+
+      - name: 카드 생성 및 발송
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          FX_SMTP_USER: ${{ secrets.FX_SMTP_USER }}
+          FX_SMTP_PASSWORD: ${{ secrets.FX_SMTP_PASSWORD }}
+          FX_MAIL_TO: ${{ secrets.FX_MAIL_TO }}
+        run: |
+          python -m fx_newsletter.main \
+            --out "$GITHUB_WORKSPACE/build/fx-cards" \
+            ${{ inputs.dry_run && '--dry-run' || '' }} \
+            ${{ inputs.no_ai && '--no-ai' || '' }}
+
+      - name: 카드 이미지 보관
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fx-cards-${{ github.run_number }}
+          path: build/fx-cards
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ codekit-config.json
 .sass-cache
 _asset_bundler_cache
 _site
+
+# 환율 카드뉴스 생성물
+build/

--- a/tools/fx_newsletter/README.md
+++ b/tools/fx_newsletter/README.md
@@ -1,0 +1,166 @@
+# 주간 환율 카드뉴스 자동 발송
+
+매주 월요일 아침, 원화 환율 4종을 정리한 카드뉴스 PNG를 만들어 메일로 보낸다.
+GitHub Actions에서 돌아가므로 별도 서버가 필요 없다.
+
+## 무엇이 오는가
+
+카드 6장이 메일 본문에 인라인으로 들어온다.
+
+| 순서 | 카드 | 내용 |
+|---|---|---|
+| 1 | 커버 | 헤드라인, 4개 통화 현재가·주간 등락률·추세 |
+| 2~5 | 통화별 | 현재가, 주간 등락, 60영업일 스파크라인, 이동평균·변동성·RSI·52주 고저 |
+| 6 | 전망 | 요약, 다음 주 체크리스트 3개, 지표 한 줄 설명 |
+
+추적 통화는 USD/KRW, 100JPY/KRW, EUR/KRW, CNY/KRW다.
+이미지를 차단한 메일 클라이언트를 위해 같은 내용의 텍스트 본문도 함께 보낸다.
+
+## 데이터 출처
+
+[Frankfurter API](https://frankfurter.dev/)를 통한 **ECB(유럽중앙은행) 기준환율**이다.
+API 키가 필요 없고 무료다.
+
+ECB는 EUR 기준으로 고시하므로 EUR 기준 시계열을 한 번만 받아 KRW 대비로 환산한다.
+따라서 매주 API 호출은 1회다.
+
+알아 둘 점:
+
+- ECB는 유럽 영업일에만, 현지 시각 오후에 고시한다. 주말·유럽 공휴일에는 새 값이 없다.
+- 서울 외환시장 종가나 은행 고시 환율(매매기준율)과는 소수점 아래에서 차이가 난다.
+  참고용 추세 파악에는 충분하지만, 실제 환전 금액 계산에는 쓰지 말 것.
+
+## 설정
+
+### 1. GitHub Secrets 등록
+
+저장소 → Settings → Secrets and variables → Actions → New repository secret.
+
+| 이름 | 필수 | 설명 |
+|---|---|---|
+| `FX_SMTP_USER` | ✅ | 보내는 Gmail 주소 (예: `you@gmail.com`) |
+| `FX_SMTP_PASSWORD` | ✅ | Gmail **앱 비밀번호** 16자리 (계정 비밀번호 아님) |
+| `FX_MAIL_TO` | | 받는 주소. 생략하면 `FX_SMTP_USER`로 보냄. 쉼표로 여러 명 지정 가능 |
+| `ANTHROPIC_API_KEY` | | 있으면 Claude가 해설을 쓴다. 없으면 지표 기반 문장으로 자동 대체 |
+
+### 2. Gmail 앱 비밀번호 발급
+
+앱 비밀번호는 2단계 인증이 켜져 있어야 만들 수 있다.
+
+1. [Google 계정 보안](https://myaccount.google.com/security)에서 2단계 인증을 켠다.
+2. [앱 비밀번호](https://myaccount.google.com/apppasswords)로 이동한다.
+3. 앱 이름을 아무거나 (예: `fx-newsletter`) 적고 생성한다.
+4. 나온 16자리를 `FX_SMTP_PASSWORD`에 넣는다. 표시된 공백은 넣어도 되고 안 넣어도 된다
+   (코드에서 공백을 제거한다).
+
+### 3. Actions 활성화 확인
+
+이 저장소는 포크로 시작했으므로 Actions 탭에서 워크플로 실행을 한 번 허용해 줘야 할 수 있다.
+
+## 실행
+
+### 자동
+
+`.github/workflows/fx-newsletter.yml`의 cron이 **일요일 23:00 UTC = 월요일 08:00 KST**에 돈다.
+
+시간을 바꾸려면 cron 값을 고친다. GitHub Actions cron은 항상 UTC이므로 KST에서 9시간을 뺀다.
+
+```yaml
+- cron: "0 23 * * 0"   # 월 08:00 KST
+- cron: "0 22 * * 5"   # 토 07:00 KST — 금요일 ECB 고시를 가장 빨리 받아보는 쪽
+```
+
+> GitHub은 60일간 커밋이 없는 저장소의 예약 워크플로를 자동으로 멈춘다.
+> 알림이 끊기면 Actions 탭에서 다시 켜면 된다. 예약 실행은 부하에 따라 몇 분에서
+> 수십 분 늦게 뜰 수 있다.
+
+### 수동
+
+Actions 탭 → "주간 환율 카드뉴스" → Run workflow.
+`dry_run`을 켜면 메일을 보내지 않고 카드만 만들어 아티팩트로 올린다.
+
+### 로컬
+
+```bash
+cd tools
+pip install -r fx_newsletter/requirements.txt
+sudo apt-get install -y fonts-nanum        # 한글 폰트. macOS는 기본 폰트로 충분
+
+# 카드만 만들어 보기 (메일 발송 없음)
+python -m fx_newsletter.main --dry-run --out build/fx-cards
+
+# 실제 발송
+export FX_SMTP_USER=you@gmail.com
+export FX_SMTP_PASSWORD='앱비밀번호16자리'
+export ANTHROPIC_API_KEY=sk-ant-...
+python -m fx_newsletter.main
+```
+
+주요 옵션:
+
+| 옵션 | 설명 |
+|---|---|
+| `--dry-run` | 카드만 만들고 메일은 보내지 않는다 |
+| `--no-ai` | Claude를 건너뛰고 규칙 기반 문장만 쓴다 |
+| `--out DIR` | 카드 저장 위치 (기본 `build/fx-cards`) |
+| `--date YYYY-MM-DD` | 발행 기준일 지정. 과거 시점 재현에 쓴다 |
+
+## 테스트
+
+네트워크 없이 전 구간을 검증한다. 합성 시계열로 환산·지표·렌더링·메일 조립을 확인한다.
+
+```bash
+cd tools
+python -m unittest discover -s fx_newsletter/tests -t .
+```
+
+## 구조
+
+```
+tools/fx_newsletter/
+├── config.py       통화 정의, 환경 변수 읽기
+├── fetch.py        Frankfurter 호출, EUR 기준 → KRW 환산
+├── indicators.py   이동평균 · RSI · 볼린저 · 변동성 · 추세 판정
+├── commentary.py   Claude 해설 생성 + 규칙 기반 대체
+├── cards.py        Pillow로 1080x1080 PNG 렌더링
+├── mailer.py       인라인 이미지 메일 조립 및 SMTP 발송
+└── main.py         파이프라인 진입점 (CLI)
+```
+
+설계상 두 군데가 **실패해도 멈추지 않는다**:
+
+- Frankfurter 호스트가 죽으면 두 번째 호스트로 넘어가고, 각 요청은 4회까지
+  지수 백오프로 재시도한다.
+- Claude 호출이 실패하거나 키가 없으면 지표 기반 문장으로 조용히 대체된다.
+  해설이 밋밋해질 뿐 뉴스레터는 나간다.
+
+반대로 환율 데이터를 아예 못 받으면 그때는 실패로 끝낸다. 틀린 숫자를 보내느니
+안 보내는 편이 낫기 때문이다.
+
+## 통화를 바꾸려면
+
+`config.py`의 `PAIRS`에 항목을 추가하거나 뺀다. Frankfurter가 지원하는 통화여야 한다
+(ECB 고시 대상 30여 종). 카드는 통화 수에 맞춰 자동으로 늘고 준다.
+
+```python
+Pair(code="GBP", label="영국 파운드", unit=1, symbol="£"),
+```
+
+`commentary.py`의 `OUTPUT_SCHEMA` 안 `pair_comments`에도 같은 코드를 넣어야
+Claude 해설이 그 통화까지 써 준다.
+
+## 비용
+
+- 환율 데이터: 무료
+- Gmail 발송: 무료
+- GitHub Actions: 퍼블릭 저장소 무료. 1회 실행 약 1~2분
+- Claude API: 주 1회, 입력 2천 토큰 안팎의 짧은 호출이라 월 단위로도 소액이다
+
+## 주의
+
+카드와 메일에 다음 문구가 항상 들어간다.
+
+> 본 자료는 공개 데이터를 정리한 참고 자료이며 투자 권유가 아닙니다.
+
+해설은 주어진 지표에서 읽히는 것만 쓰도록 프롬프트에 못 박아 두었지만,
+생성형 모델의 출력이므로 그대로 신뢰하지 말고 숫자를 함께 볼 것.

--- a/tools/fx_newsletter/__init__.py
+++ b/tools/fx_newsletter/__init__.py
@@ -1,0 +1,3 @@
+"""주간 환율 카드뉴스 자동 발송 패키지."""
+
+__all__ = ["config", "fetch", "indicators", "commentary", "cards", "mailer"]

--- a/tools/fx_newsletter/cards.py
+++ b/tools/fx_newsletter/cards.py
@@ -1,0 +1,400 @@
+"""지표와 해설을 1080x1080 카드뉴스 PNG로 렌더링한다."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from .commentary import DISCLAIMER, Commentary
+from .config import CARD_SIZE
+from .indicators import PairSnapshot
+
+log = logging.getLogger(__name__)
+
+BG = "#0B1220"
+SURFACE = "#141E33"
+LINE = "#243252"
+TEXT = "#F2F5FA"
+MUTED = "#8A99B8"
+ACCENT = "#FFC24B"
+# 한국 시장 관행: 상승은 빨강, 하락은 파랑.
+UP = "#FF5C5C"
+DOWN = "#4D8DFF"
+FLAT = "#8A99B8"
+
+MARGIN = 72
+
+# 앞에 있는 것부터 시도한다. CI에서는 fonts-nanum을 설치해 첫 후보를 쓰게 한다.
+FONT_CANDIDATES = {
+    "regular": (
+        "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    ),
+    "bold": (
+        "/usr/share/fonts/truetype/nanum/NanumGothicBold.ttf",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    ),
+}
+
+
+def _font_path(weight: str) -> str | None:
+    for path in FONT_CANDIDATES[weight]:
+        if Path(path).exists():
+            return path
+    return None
+
+
+def font(size: int, weight: str = "regular") -> ImageFont.FreeTypeFont:
+    """크기·굵기별 폰트를 캐싱해 돌려준다."""
+    key = (size, weight)
+    cached = _FONT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    path = _font_path(weight)
+    if path is None:
+        log.warning("한글 폰트를 찾지 못해 기본 폰트로 대체합니다. 한글이 깨질 수 있습니다.")
+        loaded = ImageFont.load_default()
+    else:
+        loaded = ImageFont.truetype(path, size)
+    _FONT_CACHE[key] = loaded
+    return loaded
+
+
+_FONT_CACHE: dict[tuple[int, str], ImageFont.ImageFont] = {}
+
+
+def text_width(draw: ImageDraw.ImageDraw, text: str, fnt) -> int:
+    return int(draw.textlength(text, font=fnt))
+
+
+def wrap(draw: ImageDraw.ImageDraw, text: str, fnt, max_width: int) -> list[str]:
+    """픽셀 폭 기준 줄바꿈. 한국어는 공백이 드물어 글자 단위로도 끊는다."""
+    lines: list[str] = []
+    for paragraph in text.split("\n"):
+        current = ""
+        for token in paragraph.split(" "):
+            candidate = f"{current} {token}".strip()
+            if current and text_width(draw, candidate, fnt) > max_width:
+                lines.append(current)
+                current = token
+            else:
+                current = candidate
+            # 공백 없는 긴 덩어리는 글자 단위로 쪼갠다.
+            while text_width(draw, current, fnt) > max_width and len(current) > 1:
+                cut = len(current)
+                while cut > 1 and text_width(draw, current[:cut], fnt) > max_width:
+                    cut -= 1
+                lines.append(current[:cut])
+                current = current[cut:]
+        lines.append(current)
+    return [ln for ln in lines if ln != ""] or [""]
+
+
+def draw_wrapped(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int],
+    text: str,
+    fnt,
+    fill: str,
+    max_width: int,
+    line_height: int,
+    max_lines: int | None = None,
+) -> int:
+    """줄바꿈해 그리고, 다음 요소가 시작할 y좌표를 돌려준다."""
+    x, y = xy
+    lines = wrap(draw, text, fnt, max_width)
+    if max_lines is not None and len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = lines[-1][:-1] + "…"
+    for line in lines:
+        draw.text((x, y), line, font=fnt, fill=fill)
+        y += line_height
+    return y
+
+
+def new_card() -> tuple[Image.Image, ImageDraw.ImageDraw]:
+    image = Image.new("RGB", (CARD_SIZE, CARD_SIZE), BG)
+    return image, ImageDraw.Draw(image)
+
+
+def _color_for(direction: str) -> str:
+    return {"up": UP, "down": DOWN}.get(direction, FLAT)
+
+
+def _fmt(value: float, digits: int = 2) -> str:
+    return f"{value:,.{digits}f}"
+
+
+def _signed(value: float, digits: int = 2) -> str:
+    return f"{'+' if value > 0 else ''}{value:,.{digits}f}"
+
+
+def _footer(draw: ImageDraw.ImageDraw, note: str = "") -> None:
+    draw.line(
+        [(MARGIN, CARD_SIZE - 108), (CARD_SIZE - MARGIN, CARD_SIZE - 108)],
+        fill=LINE,
+        width=2,
+    )
+    left = note or "출처: ECB 기준환율 (Frankfurter API)"
+    draw.text((MARGIN, CARD_SIZE - 86), left, font=font(24), fill=MUTED)
+    draw.text((MARGIN, CARD_SIZE - 52), DISCLAIMER, font=font(21), fill=MUTED)
+
+
+def draw_sparkline(
+    draw: ImageDraw.ImageDraw,
+    values: tuple[float, ...],
+    box: tuple[int, int, int, int],
+    color: str,
+) -> None:
+    """추세를 한눈에 보이게 하는 미니 라인차트."""
+    x0, y0, x1, y1 = box
+    draw.rounded_rectangle(box, radius=20, fill=SURFACE)
+    if len(values) < 2:
+        return
+
+    low, high = min(values), max(values)
+    span = high - low
+    pad = 26
+    inner_w = x1 - x0 - pad * 2
+    inner_h = y1 - y0 - pad * 2
+
+    def point(i: int, v: float) -> tuple[float, float]:
+        px = x0 + pad + inner_w * i / (len(values) - 1)
+        # 값이 전부 같으면 중앙에 수평선을 그린다.
+        ratio = 0.5 if span == 0 else (v - low) / span
+        py = y0 + pad + inner_h * (1 - ratio)
+        return px, py
+
+    points = [point(i, v) for i, v in enumerate(values)]
+    draw.polygon(
+        [(points[0][0], y1 - pad)] + points + [(points[-1][0], y1 - pad)],
+        fill=SURFACE,
+    )
+    draw.line(points, fill=color, width=5, joint="curve")
+    draw.ellipse(
+        [points[-1][0] - 9, points[-1][1] - 9, points[-1][0] + 9, points[-1][1] + 9],
+        fill=color,
+    )
+
+
+def cover_card(snapshots: list[PairSnapshot], commentary: Commentary, issued: dt.date) -> Image.Image:
+    image, draw = new_card()
+    draw.rectangle([0, 0, CARD_SIZE, 12], fill=ACCENT)
+
+    draw.text((MARGIN, 108), "WEEKLY FX BRIEF", font=font(30, "bold"), fill=ACCENT)
+    draw.text((MARGIN, 158), "주간 환율 브리핑", font=font(76, "bold"), fill=TEXT)
+    draw.text(
+        (MARGIN, 254),
+        f"{issued.strftime('%Y년 %m월 %d일')} 발행",
+        font=font(28),
+        fill=MUTED,
+    )
+
+    y = draw_wrapped(
+        draw,
+        (MARGIN, 330),
+        commentary.headline,
+        font(46, "bold"),
+        ACCENT,
+        CARD_SIZE - MARGIN * 2,
+        62,
+        max_lines=2,
+    )
+
+    y += 30
+    row_h = 120
+    for snapshot in snapshots:
+        draw.rounded_rectangle(
+            [MARGIN, y, CARD_SIZE - MARGIN, y + row_h - 16], radius=18, fill=SURFACE
+        )
+        draw.text((MARGIN + 28, y + 16), snapshot.display_name, font=font(30, "bold"), fill=TEXT)
+        draw.text(
+            (MARGIN + 28, y + 58),
+            f"{snapshot.label} · {snapshot.trend}",
+            font=font(23),
+            fill=MUTED,
+        )
+
+        value_text = _fmt(snapshot.latest)
+        value_font = font(42, "bold")
+        draw.text(
+            (CARD_SIZE - MARGIN - 28 - text_width(draw, value_text, value_font), y + 16),
+            value_text,
+            font=value_font,
+            fill=TEXT,
+        )
+        if snapshot.week:
+            change_text = f"{_signed(snapshot.week.pct, 2)}%"
+            change_font = font(27, "bold")
+            draw.text(
+                (CARD_SIZE - MARGIN - 28 - text_width(draw, change_text, change_font), y + 66),
+                change_text,
+                font=change_font,
+                fill=_color_for(snapshot.direction),
+            )
+        y += row_h
+
+    _footer(draw)
+    return image
+
+
+def pair_card(snapshot: PairSnapshot, comment: str) -> Image.Image:
+    image, draw = new_card()
+    color = _color_for(snapshot.direction)
+    draw.rectangle([0, 0, CARD_SIZE, 12], fill=color)
+
+    draw.text((MARGIN, 96), snapshot.label, font=font(30), fill=MUTED)
+    draw.text((MARGIN, 138), snapshot.display_name, font=font(58, "bold"), fill=TEXT)
+
+    draw.text((MARGIN, 236), _fmt(snapshot.latest), font=font(112, "bold"), fill=TEXT)
+    draw.text((MARGIN, 366), "원", font=font(32), fill=MUTED)
+
+    if snapshot.week:
+        badge = f"주간 {_signed(snapshot.week.delta)}원 ({_signed(snapshot.week.pct)}%)"
+        badge_font = font(30, "bold")
+        width = text_width(draw, badge, badge_font)
+        draw.rounded_rectangle([MARGIN + 60, 362, MARGIN + 60 + width + 44, 414], radius=26, fill=color)
+        draw.text((MARGIN + 82, 372), badge, font=badge_font, fill=BG)
+
+    draw_sparkline(draw, snapshot.spark, (MARGIN, 442, CARD_SIZE - MARGIN, 690), color)
+    draw.text((MARGIN + 26, 452), "최근 60영업일", font=font(22), fill=MUTED)
+
+    rows = [
+        ("20일 이동평균", _fmt(snapshot.sma20) if snapshot.sma20 else "-"),
+        ("60일 이동평균", _fmt(snapshot.sma60) if snapshot.sma60 else "-"),
+        ("연율 변동성", f"{snapshot.volatility:.1f}%" if snapshot.volatility else "-"),
+        ("RSI(14)", f"{snapshot.rsi14:.0f}" if snapshot.rsi14 else "-"),
+        ("52주 고점", _fmt(snapshot.high52) if snapshot.high52 else "-"),
+        ("52주 저점", _fmt(snapshot.low52) if snapshot.low52 else "-"),
+    ]
+    col_w = (CARD_SIZE - MARGIN * 2) // 3
+    for index, (name, value) in enumerate(rows):
+        cx = MARGIN + (index % 3) * col_w
+        cy = 716 + (index // 3) * 78
+        draw.text((cx, cy), name, font=font(22), fill=MUTED)
+        draw.text((cx, cy + 30), value, font=font(32, "bold"), fill=TEXT)
+
+    draw_wrapped(
+        draw,
+        (MARGIN, 878),
+        f"{snapshot.trend} · {comment}",
+        font(26),
+        TEXT,
+        CARD_SIZE - MARGIN * 2,
+        38,
+        max_lines=2,
+    )
+    _footer(draw, f"기준일 {snapshot.latest_date.isoformat()} · ECB 고시환율")
+    return image
+
+
+LEGEND = (
+    ("RSI(14)", "70 위는 과매수, 30 아래는 과매도로 본다"),
+    ("연율 변동성", "최근 20일 흔들림을 1년치로 환산한 값"),
+    ("이동평균", "20일선이 60일선 위면 상승 배열"),
+)
+
+
+LEGEND_BOTTOM = CARD_SIZE - 136  # 푸터 구분선 위에 남기는 여백
+
+
+def _draw_legend(draw: ImageDraw.ImageDraw, min_top: int) -> None:
+    """카드에 쓰인 지표를 한 줄씩 풀어 준다. 푸터 바로 위에 붙여 그린다.
+
+    본문이 길어 자리가 안 나면 그리지 않는다. 범례는 있으면 좋은 정보이지
+    본문을 밀어낼 만한 것은 아니다.
+    """
+    height = 56 + len(LEGEND) * 44
+    top = LEGEND_BOTTOM - height
+    if top < min_top:
+        return
+    draw.rounded_rectangle(
+        [MARGIN, top, CARD_SIZE - MARGIN, top + height], radius=20, fill=SURFACE
+    )
+    draw.text((MARGIN + 28, top + 18), "지표 한 줄 설명", font=font(24, "bold"), fill=MUTED)
+    row_y = top + 56
+    for name, description in LEGEND:
+        draw.text((MARGIN + 28, row_y), name, font=font(23, "bold"), fill=ACCENT)
+        draw.text((MARGIN + 220, row_y), description, font=font(23), fill=MUTED)
+        row_y += 44
+
+
+def outlook_card(commentary: Commentary) -> Image.Image:
+    image, draw = new_card()
+    draw.rectangle([0, 0, CARD_SIZE, 12], fill=ACCENT)
+
+    draw.text((MARGIN, 100), "OUTLOOK", font=font(30, "bold"), fill=ACCENT)
+    draw.text((MARGIN, 148), "이번 주 정리와 관전 포인트", font=font(52, "bold"), fill=TEXT)
+
+    y = draw_wrapped(
+        draw,
+        (MARGIN, 258),
+        commentary.summary,
+        font(32),
+        TEXT,
+        CARD_SIZE - MARGIN * 2,
+        50,
+        max_lines=6,
+    )
+
+    y += 40
+    draw.text((MARGIN, y), "다음 주 체크리스트", font=font(28, "bold"), fill=ACCENT)
+    y += 56
+    for index, point in enumerate(commentary.watchpoints, start=1):
+        draw.ellipse([MARGIN, y + 8, MARGIN + 34, y + 42], fill=SURFACE, outline=ACCENT, width=2)
+        number = str(index)
+        draw.text(
+            (MARGIN + 17 - text_width(draw, number, font(22, "bold")) // 2, y + 14),
+            number,
+            font=font(22, "bold"),
+            fill=ACCENT,
+        )
+        y = draw_wrapped(
+            draw,
+            (MARGIN + 54, y + 6),
+            point,
+            font(28),
+            TEXT,
+            CARD_SIZE - MARGIN * 2 - 54,
+            42,
+            max_lines=2,
+        )
+        y += 22
+
+    _draw_legend(draw, y + 30)
+
+    note = "해설 생성: Claude" if commentary.source == "claude" else "해설 생성: 지표 규칙 기반"
+    _footer(draw, note)
+    return image
+
+
+def render_all(
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    out_dir: Path,
+) -> list[Path]:
+    """카드 전체를 파일로 떨어뜨리고 경로 목록을 순서대로 반환한다."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+
+    def save(image: Image.Image, name: str) -> None:
+        path = out_dir / name
+        image.save(path, "PNG", optimize=True)
+        paths.append(path)
+
+    save(cover_card(snapshots, commentary, issued), "01-cover.png")
+    for index, snapshot in enumerate(snapshots, start=2):
+        comment = commentary.pair_comments.get(snapshot.code, snapshot.trend)
+        save(pair_card(snapshot, comment), f"{index:02d}-{snapshot.code.lower()}.png")
+    save(outlook_card(commentary), f"{len(snapshots) + 2:02d}-outlook.png")
+    return paths

--- a/tools/fx_newsletter/commentary.py
+++ b/tools/fx_newsletter/commentary.py
@@ -1,0 +1,245 @@
+"""주간 전망 코멘트를 만든다.
+
+기본은 Claude(Anthropic Messages API)로 한국어 해설을 생성하되,
+API 키가 없거나 호출이 실패하면 지표 기반 규칙 문장으로 대체한다.
+어느 쪽이든 카드 렌더러가 기대하는 동일한 구조를 돌려준다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, asdict
+
+from .config import CLAUDE_MODEL
+from .indicators import PairSnapshot
+
+log = logging.getLogger(__name__)
+
+DISCLAIMER = "본 자료는 공개 데이터를 정리한 참고 자료이며 투자 권유가 아닙니다."
+
+SYSTEM_PROMPT = """당신은 한국 독자를 위한 외환시장 카드뉴스를 쓰는 애널리스트다.
+주어진 것은 ECB 고시 기준 원화 환율의 계산된 지표뿐이다. 다음을 지켜라.
+
+- 주어진 수치에서 곧바로 읽히는 사실만 쓴다. 뉴스·정책·발언을 지어내지 않는다.
+- 수치가 없는 인과("연준 발언으로 인해" 등)를 만들지 않는다. 지표가 말하는 것만 말한다.
+- 단정적 가격 예측을 하지 않는다. 방향성과 조건을 함께 쓴다.
+- 카드뉴스 문체: 짧고 평이한 한국어 문장. 한 문장 40자 안팎.
+- 전문 용어를 쓰면 바로 뒤에 쉬운 말로 풀어 준다."""
+
+
+@dataclass
+class Commentary:
+    """카드에 얹을 해설 묶음."""
+
+    headline: str
+    summary: str
+    pair_comments: dict[str, str]
+    watchpoints: list[str]
+    source: str  # "claude" 또는 "rules"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "headline": {
+            "type": "string",
+            "description": "이번 주 환율을 한 줄로 요약한 제목. 25자 이내.",
+        },
+        "summary": {
+            "type": "string",
+            "description": "전체 흐름 요약. 2~3문장, 160자 이내.",
+        },
+        "pair_comments": {
+            "type": "object",
+            "description": "통화 코드별 한 줄 해설. 각 60자 이내.",
+            "properties": {
+                "USD": {"type": "string"},
+                "JPY": {"type": "string"},
+                "EUR": {"type": "string"},
+                "CNY": {"type": "string"},
+            },
+            "required": ["USD", "JPY", "EUR", "CNY"],
+            "additionalProperties": False,
+        },
+        "watchpoints": {
+            "type": "array",
+            "description": "다음 주 확인할 관전 포인트 3개. 각 40자 이내.",
+            "items": {"type": "string"},
+        },
+    },
+    "required": ["headline", "summary", "pair_comments", "watchpoints"],
+    "additionalProperties": False,
+}
+
+
+def _round(value: float | None, digits: int = 2) -> float | None:
+    return None if value is None else round(value, digits)
+
+
+def snapshots_to_payload(snapshots: list[PairSnapshot]) -> list[dict]:
+    """모델에 넘길 최소한의 숫자 묶음. 시계열 원본은 보내지 않는다."""
+    payload = []
+    for s in snapshots:
+        payload.append(
+            {
+                "통화쌍": s.display_name,
+                "코드": s.code,
+                "기준일": s.latest_date.isoformat(),
+                "현재가": _round(s.latest),
+                "주간등락": _round(s.week.delta) if s.week else None,
+                "주간등락률%": _round(s.week.pct) if s.week else None,
+                "월간등락률%": _round(s.month.pct) if s.month else None,
+                "20일이동평균": _round(s.sma20),
+                "60일이동평균": _round(s.sma60),
+                "연율변동성%": _round(s.volatility, 1),
+                "RSI14": _round(s.rsi14, 1),
+                "볼린저위치%": _round(s.bollinger_pct, 1),
+                "52주고점": _round(s.high52),
+                "52주저점": _round(s.low52),
+                "추세": s.trend,
+            }
+        )
+    return payload
+
+
+def _describe(snapshot: PairSnapshot) -> str:
+    """지표만으로 만드는 통화별 한 줄 해설."""
+    week = snapshot.week
+    if week is None:
+        return f"{snapshot.trend}. 비교할 지난주 고시가 없습니다."
+
+    move = "올랐" if week.delta > 0 else ("내렸" if week.delta < 0 else "보합이었")
+    parts = [f"한 주간 {abs(week.pct):.1f}% {move}습니다"]
+
+    if snapshot.rsi14 is not None:
+        if snapshot.rsi14 >= 70:
+            parts.append("RSI가 과매수 구간입니다")
+        elif snapshot.rsi14 <= 30:
+            parts.append("RSI가 과매도 구간입니다")
+
+    if snapshot.bollinger_pct is not None:
+        if snapshot.bollinger_pct >= 100:
+            parts.append("볼린저 상단을 넘었습니다")
+        elif snapshot.bollinger_pct <= 0:
+            parts.append("볼린저 하단을 밑돌았습니다")
+
+    if len(parts) == 1:
+        # 덧붙일 특이사항이 없을 때만 추세를 문장으로 쓴다. 카드에는 이미 추세가 찍힌다.
+        parts.append(snapshot.trend + "가 이어지고 있습니다")
+    return ". ".join(parts[:3]) + "."
+
+
+def rule_based(snapshots: list[PairSnapshot]) -> Commentary:
+    """API 없이 지표만으로 만드는 대체 해설."""
+    usd = next((s for s in snapshots if s.code == "USD"), None)
+    if usd and usd.week:
+        arrow = "상승" if usd.week.delta > 0 else ("하락" if usd.week.delta < 0 else "보합")
+        headline = f"원/달러 {arrow}, 주간 {abs(usd.week.pct):.1f}%"
+    else:
+        headline = "주간 원화 환율 동향"
+
+    rising = [s.display_name for s in snapshots if s.direction == "up"]
+    falling = [s.display_name for s in snapshots if s.direction == "down"]
+    lines = []
+    if rising:
+        lines.append(f"{', '.join(rising)}이(가) 올라 원화가 그만큼 약해졌습니다.")
+    if falling:
+        lines.append(f"{', '.join(falling)}이(가) 내려 원화가 그만큼 강해졌습니다.")
+    if not lines:
+        lines.append("네 통화 모두 뚜렷한 방향 없이 좁은 범위에 머물렀습니다.")
+
+    most_volatile = max(
+        (s for s in snapshots if s.volatility is not None),
+        key=lambda s: s.volatility,
+        default=None,
+    )
+    if most_volatile:
+        lines.append(
+            f"변동성은 {most_volatile.display_name}이(가) 연율 "
+            f"{most_volatile.volatility:.1f}%로 가장 컸습니다."
+        )
+
+    watchpoints = []
+    for s in snapshots:
+        if s.rsi14 is not None and (s.rsi14 >= 70 or s.rsi14 <= 30):
+            zone = "과매수" if s.rsi14 >= 70 else "과매도"
+            watchpoints.append(f"{s.display_name} RSI {s.rsi14:.0f} — {zone} 되돌림 여부")
+        if s.high52 and s.latest >= s.high52 * 0.995:
+            watchpoints.append(f"{s.display_name} 52주 고점권 돌파 시도")
+        if s.low52 and s.latest <= s.low52 * 1.005:
+            watchpoints.append(f"{s.display_name} 52주 저점권 지지 여부")
+    if not watchpoints:
+        watchpoints.append("20일·60일 이동평균 교차 여부")
+    watchpoints.append("주요국 금리 결정 일정 확인")
+
+    return Commentary(
+        headline=headline,
+        summary=" ".join(lines),
+        pair_comments={s.code: _describe(s) for s in snapshots},
+        watchpoints=watchpoints[:3],
+        source="rules",
+    )
+
+
+def _call_claude(snapshots: list[PairSnapshot]) -> Commentary:
+    import anthropic
+
+    client = anthropic.Anthropic()
+    payload = snapshots_to_payload(snapshots)
+
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=16000,
+        system=SYSTEM_PROMPT,
+        # 요약 성격의 정형 작업이라 effort를 medium으로 낮춰 비용을 줄인다.
+        output_config={
+            "effort": "medium",
+            "format": {"type": "json_schema", "schema": OUTPUT_SCHEMA},
+        },
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "아래는 ECB 고시 기준으로 계산한 원화 환율 지표다. "
+                    "이 숫자만 근거로 주간 카드뉴스용 해설을 작성하라.\n\n"
+                    + json.dumps(payload, ensure_ascii=False, indent=2)
+                ),
+            }
+        ],
+    )
+
+    if response.stop_reason == "refusal":
+        raise RuntimeError(f"모델이 요청을 거절했습니다: {response.stop_details}")
+
+    text = next(block.text for block in response.content if block.type == "text")
+    data = json.loads(text)
+    return Commentary(
+        headline=data["headline"].strip(),
+        summary=data["summary"].strip(),
+        pair_comments={k: v.strip() for k, v in data["pair_comments"].items()},
+        watchpoints=[w.strip() for w in data["watchpoints"]][:3],
+        source="claude",
+    )
+
+
+def build(snapshots: list[PairSnapshot], use_ai: bool = True) -> Commentary:
+    """AI 해설을 시도하고, 불가능하면 규칙 기반으로 조용히 내려앉는다."""
+    if not use_ai:
+        return rule_based(snapshots)
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        log.warning("ANTHROPIC_API_KEY가 없어 규칙 기반 해설로 대체합니다.")
+        return rule_based(snapshots)
+
+    try:
+        return _call_claude(snapshots)
+    except ImportError:
+        log.warning("anthropic 패키지가 없어 규칙 기반 해설로 대체합니다.")
+    except Exception as exc:
+        # 뉴스레터는 해설이 다소 밋밋해도 나가는 편이 낫다. 실패해도 멈추지 않는다.
+        log.warning("Claude 호출 실패(%s: %s). 규칙 기반 해설로 대체합니다.", type(exc).__name__, exc)
+    return rule_based(snapshots)

--- a/tools/fx_newsletter/config.py
+++ b/tools/fx_newsletter/config.py
@@ -1,0 +1,79 @@
+"""환경 변수와 통화 정의를 한곳에 모은 설정 모듈."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Pair:
+    """KRW 대비 표시할 통화 한 종류."""
+
+    code: str          # ISO 코드 (USD, JPY, EUR, CNY)
+    label: str         # 카드에 찍을 이름
+    unit: int          # 표시 단위 (엔화는 100엔 기준)
+    symbol: str        # 통화 기호
+
+    @property
+    def display_name(self) -> str:
+        if self.unit == 1:
+            return f"{self.code}/KRW"
+        return f"{self.unit}{self.code}/KRW"
+
+
+PAIRS: tuple[Pair, ...] = (
+    Pair(code="USD", label="미국 달러", unit=1, symbol="$"),
+    Pair(code="JPY", label="일본 엔", unit=100, symbol="¥"),
+    Pair(code="EUR", label="유로", unit=1, symbol="€"),
+    Pair(code="CNY", label="중국 위안", unit=1, symbol="¥"),
+)
+
+# 지표 계산에 필요한 과거 구간. 52주 고저·60일 이동평균을 확보하려면 넉넉히 잡는다.
+HISTORY_DAYS = 500
+
+# 카드 규격
+CARD_SIZE = 1080
+
+CLAUDE_MODEL = os.environ.get("FX_CLAUDE_MODEL", "claude-opus-5")
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+@dataclass(frozen=True)
+class MailConfig:
+    """Gmail SMTP 발송 설정."""
+
+    host: str
+    port: int
+    user: str
+    password: str
+    sender_name: str
+    recipients: tuple[str, ...]
+
+    @classmethod
+    def from_env(cls) -> "MailConfig":
+        user = _env("FX_SMTP_USER")
+        raw_to = _env("FX_MAIL_TO") or user
+        recipients = tuple(a.strip() for a in raw_to.split(",") if a.strip())
+        return cls(
+            host=_env("FX_SMTP_HOST", "smtp.gmail.com"),
+            port=int(_env("FX_SMTP_PORT", "465")),
+            user=user,
+            # Gmail 앱 비밀번호는 표시할 때 4자씩 띄어쓰기가 들어가므로 공백을 지운다.
+            password=_env("FX_SMTP_PASSWORD").replace(" ", ""),
+            sender_name=_env("FX_MAIL_FROM_NAME", "주간 환율 브리핑"),
+            recipients=recipients,
+        )
+
+    def validate(self) -> list[str]:
+        missing = []
+        if not self.user:
+            missing.append("FX_SMTP_USER")
+        if not self.password:
+            missing.append("FX_SMTP_PASSWORD")
+        if not self.recipients:
+            missing.append("FX_MAIL_TO")
+        return missing

--- a/tools/fx_newsletter/fetch.py
+++ b/tools/fx_newsletter/fetch.py
@@ -1,0 +1,122 @@
+"""Frankfurter(ECB 기준환율) API에서 원화 환율 시계열을 가져온다.
+
+ECB는 EUR을 기준으로 환율을 고시하므로 EUR 기준 시계열을 한 번만 받아
+KRW 대비 환율로 환산한다. 요청이 한 번뿐이라 API 부담이 작고, 모든 통화가
+동일한 고시일 집합을 공유하므로 날짜 정렬 문제도 생기지 않는다.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import time
+from dataclasses import dataclass
+
+import requests
+
+from .config import PAIRS, Pair
+
+# Frankfurter는 도메인을 .dev로 옮겼으나 구 도메인도 살아 있다. 순서대로 시도한다.
+API_HOSTS = (
+    "https://api.frankfurter.dev/v1",
+    "https://api.frankfurter.app",
+)
+
+BASE = "EUR"
+TIMEOUT = 30
+MAX_ATTEMPTS = 4
+
+
+class FetchError(RuntimeError):
+    """모든 API 호스트에서 시계열을 받지 못했을 때."""
+
+
+@dataclass(frozen=True)
+class Series:
+    """한 통화쌍의 날짜 오름차순 시계열."""
+
+    pair: Pair
+    dates: tuple[dt.date, ...]
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.dates) != len(self.values):
+            raise ValueError("dates와 values 길이가 다릅니다")
+
+    @property
+    def latest_date(self) -> dt.date:
+        return self.dates[-1]
+
+    @property
+    def latest(self) -> float:
+        return self.values[-1]
+
+    def value_on_or_before(self, target: dt.date) -> tuple[dt.date, float] | None:
+        """target 이하의 가장 최근 고시값. 주말·공휴일 공백을 흡수한다."""
+        for i in range(len(self.dates) - 1, -1, -1):
+            if self.dates[i] <= target:
+                return self.dates[i], self.values[i]
+        return None
+
+
+def _get_json(url: str) -> dict:
+    """지수 백오프로 재시도하며 JSON을 받아온다."""
+    last_error: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            response = requests.get(url, timeout=TIMEOUT)
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:  # 네트워크·HTTP·JSON 오류를 모두 재시도 대상으로 본다
+            last_error = exc
+            if attempt < MAX_ATTEMPTS - 1:
+                time.sleep(2 ** (attempt + 1))
+    raise FetchError(f"{url} 요청 실패: {last_error}")
+
+
+def fetch_raw(start: dt.date, end: dt.date, session_get=_get_json) -> dict:
+    """EUR 기준 시계열 원본을 받아온다. 호스트를 순서대로 시도한다."""
+    # 기준통화(EUR)는 symbols에 넣으면 API가 거부하므로 반드시 빼둔다.
+    symbols = ",".join(sorted(({p.code for p in PAIRS} | {"KRW"}) - {BASE}))
+    errors: list[str] = []
+    for host in API_HOSTS:
+        url = f"{host}/{start.isoformat()}..{end.isoformat()}?base={BASE}&symbols={symbols}"
+        try:
+            payload = session_get(url)
+        except Exception as exc:
+            errors.append(f"{host}: {exc}")
+            continue
+        if payload.get("rates"):
+            return payload
+        errors.append(f"{host}: 응답에 rates가 비어 있음")
+    raise FetchError("환율 시계열을 가져오지 못했습니다 -> " + " | ".join(errors))
+
+
+def to_series(payload: dict) -> dict[str, Series]:
+    """EUR 기준 원본을 통화쌍별 KRW 환산 시계열로 바꾼다."""
+    rates: dict[str, dict[str, float]] = payload.get("rates") or {}
+    if not rates:
+        raise FetchError("응답에 rates가 없습니다")
+
+    result: dict[str, Series] = {}
+    for pair in PAIRS:
+        dates: list[dt.date] = []
+        values: list[float] = []
+        for day in sorted(rates):
+            row = rates[day]
+            krw_per_eur = row.get("KRW")
+            # EUR은 기준 통화라 응답에 자기 자신이 없다.
+            unit_per_eur = 1.0 if pair.code == BASE else row.get(pair.code)
+            if not krw_per_eur or not unit_per_eur:
+                continue  # 일부 통화만 빠진 날은 건너뛴다
+            dates.append(dt.date.fromisoformat(day))
+            values.append(pair.unit * krw_per_eur / unit_per_eur)
+        if len(values) < 2:
+            raise FetchError(f"{pair.display_name} 시계열이 너무 짧습니다 ({len(values)}건)")
+        result[pair.code] = Series(pair=pair, dates=tuple(dates), values=tuple(values))
+    return result
+
+
+def load_series(today: dt.date, history_days: int, session_get=_get_json) -> dict[str, Series]:
+    """오늘 기준 history_days 만큼의 통화쌍 시계열을 반환한다."""
+    payload = fetch_raw(today - dt.timedelta(days=history_days), today, session_get=session_get)
+    return to_series(payload)

--- a/tools/fx_newsletter/indicators.py
+++ b/tools/fx_newsletter/indicators.py
@@ -1,0 +1,185 @@
+"""환율 시계열에서 카드에 실을 지표를 계산한다.
+
+ECB 고시는 영업일 기준이라 관측치가 주 5회다. 따라서 '지난주 대비' 같은
+비교는 관측치 개수가 아니라 달력 날짜로 되짚어 찾는다.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass, field
+
+from .fetch import Series
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(frozen=True)
+class Change:
+    """기준 시점 대비 변화량."""
+
+    ref_date: dt.date
+    ref_value: float
+    delta: float
+    pct: float
+
+
+@dataclass(frozen=True)
+class PairSnapshot:
+    """카드 한 장을 채우는 데 필요한 통화쌍 지표 묶음."""
+
+    code: str
+    display_name: str
+    label: str
+    latest_date: dt.date
+    latest: float
+    week: Change | None
+    month: Change | None
+    sma20: float | None
+    sma60: float | None
+    volatility: float | None
+    rsi14: float | None
+    bollinger_pct: float | None
+    high52: float | None
+    low52: float | None
+    trend: str
+    spark: tuple[float, ...] = field(default=())
+
+    @property
+    def direction(self) -> str:
+        """주간 등락 방향. 카드 색상과 문구를 고르는 데 쓴다."""
+        if self.week is None or abs(self.week.pct) < 0.05:
+            return "flat"
+        return "up" if self.week.delta > 0 else "down"
+
+
+def _mean(values) -> float:
+    values = list(values)
+    return sum(values) / len(values)
+
+
+def _stdev(values) -> float | None:
+    values = list(values)
+    if len(values) < 2:
+        return None
+    avg = _mean(values)
+    return math.sqrt(sum((v - avg) ** 2 for v in values) / (len(values) - 1))
+
+
+def sma(values: tuple[float, ...], window: int) -> float | None:
+    if len(values) < window:
+        return None
+    return _mean(values[-window:])
+
+
+def annualized_volatility(values: tuple[float, ...], window: int = 20) -> float | None:
+    """일간 로그수익률의 표준편차를 연율화한 값(%)."""
+    if len(values) < window + 1:
+        return None
+    recent = values[-(window + 1):]
+    returns = [
+        math.log(recent[i] / recent[i - 1])
+        for i in range(1, len(recent))
+        if recent[i] > 0 and recent[i - 1] > 0
+    ]
+    deviation = _stdev(returns)
+    if deviation is None:
+        return None
+    return deviation * math.sqrt(TRADING_DAYS_PER_YEAR) * 100
+
+
+def rsi(values: tuple[float, ...], window: int = 14) -> float | None:
+    """Wilder 방식 RSI. 과매수/과매도 판단에 쓴다."""
+    if len(values) < window + 1:
+        return None
+    deltas = [values[i] - values[i - 1] for i in range(1, len(values))]
+    gains = [max(d, 0.0) for d in deltas]
+    losses = [max(-d, 0.0) for d in deltas]
+
+    avg_gain = _mean(gains[:window])
+    avg_loss = _mean(losses[:window])
+    for i in range(window, len(deltas)):
+        avg_gain = (avg_gain * (window - 1) + gains[i]) / window
+        avg_loss = (avg_loss * (window - 1) + losses[i]) / window
+
+    if avg_loss == 0:
+        return 100.0 if avg_gain > 0 else 50.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def bollinger_pct(values: tuple[float, ...], window: int = 20, mult: float = 2.0) -> float | None:
+    """볼린저 밴드 내 위치(%B). 0이면 하단, 100이면 상단."""
+    if len(values) < window:
+        return None
+    recent = values[-window:]
+    middle = _mean(recent)
+    deviation = _stdev(recent)
+    if not deviation:
+        return None
+    lower = middle - mult * deviation
+    upper = middle + mult * deviation
+    return (values[-1] - lower) / (upper - lower) * 100
+
+
+def _change(series: Series, days: int) -> Change | None:
+    found = series.value_on_or_before(series.latest_date - dt.timedelta(days=days))
+    if found is None:
+        return None
+    ref_date, ref_value = found
+    if ref_date == series.latest_date or ref_value == 0:
+        return None
+    delta = series.latest - ref_value
+    return Change(
+        ref_date=ref_date,
+        ref_value=ref_value,
+        delta=delta,
+        pct=delta / ref_value * 100,
+    )
+
+
+def _trend_label(latest: float, sma20: float | None, sma60: float | None) -> str:
+    """이동평균 배열로 추세를 한 단어로 요약한다."""
+    if sma20 is None or sma60 is None:
+        return "판단 보류"
+    if latest > sma20 > sma60:
+        return "상승 추세"
+    if latest < sma20 < sma60:
+        return "하락 추세"
+    if sma20 > sma60:
+        return "상승 속 조정"
+    return "하락 속 반등"
+
+
+def build_snapshot(series: Series, spark_points: int = 60) -> PairSnapshot:
+    """시계열 하나를 카드용 스냅샷으로 압축한다."""
+    values = series.values
+    window52 = values[-TRADING_DAYS_PER_YEAR:] if len(values) >= 2 else values
+    sma20 = sma(values, 20)
+    sma60 = sma(values, 60)
+    return PairSnapshot(
+        code=series.pair.code,
+        display_name=series.pair.display_name,
+        label=series.pair.label,
+        latest_date=series.latest_date,
+        latest=series.latest,
+        week=_change(series, 7),
+        month=_change(series, 30),
+        sma20=sma20,
+        sma60=sma60,
+        volatility=annualized_volatility(values),
+        rsi14=rsi(values),
+        bollinger_pct=bollinger_pct(values),
+        high52=max(window52),
+        low52=min(window52),
+        trend=_trend_label(series.latest, sma20, sma60),
+        spark=values[-spark_points:],
+    )
+
+
+def build_snapshots(series_map: dict[str, Series]) -> list[PairSnapshot]:
+    """설정에 정의된 통화 순서를 유지한 채 스냅샷 목록을 만든다."""
+    from .config import PAIRS
+
+    return [build_snapshot(series_map[p.code]) for p in PAIRS if p.code in series_map]

--- a/tools/fx_newsletter/mailer.py
+++ b/tools/fx_newsletter/mailer.py
@@ -1,0 +1,140 @@
+"""카드 PNG를 본문에 삽입한 메일을 Gmail SMTP로 보낸다."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import mimetypes
+import smtplib
+from email.message import EmailMessage
+from email.utils import make_msgid
+from pathlib import Path
+
+from .commentary import DISCLAIMER, Commentary
+from .config import MailConfig
+from .indicators import PairSnapshot
+
+log = logging.getLogger(__name__)
+
+
+def subject_line(commentary: Commentary, issued: dt.date) -> str:
+    return f"[주간 환율] {issued.strftime('%m/%d')} · {commentary.headline}"
+
+
+def _sign(value: float) -> str:
+    return f"{'+' if value > 0 else ''}{value:,.2f}"
+
+
+def plain_body(snapshots: list[PairSnapshot], commentary: Commentary, issued: dt.date) -> str:
+    """이미지를 막아 둔 클라이언트에서도 내용이 전달되도록 하는 텍스트 대체본."""
+    lines = [
+        f"주간 환율 브리핑 — {issued.strftime('%Y년 %m월 %d일')}",
+        "",
+        commentary.headline,
+        "",
+        commentary.summary,
+        "",
+        "[통화별 현황]",
+    ]
+    for s in snapshots:
+        change = f"{_sign(s.week.delta)}원 ({_sign(s.week.pct)}%)" if s.week else "비교 불가"
+        lines.append(f"- {s.display_name}: {s.latest:,.2f}원 / 주간 {change} / {s.trend}")
+        comment = commentary.pair_comments.get(s.code)
+        if comment:
+            lines.append(f"  {comment}")
+
+    lines += ["", "[다음 주 체크리스트]"]
+    lines += [f"{i}. {w}" for i, w in enumerate(commentary.watchpoints, start=1)]
+    lines += [
+        "",
+        f"기준일: {snapshots[0].latest_date.isoformat() if snapshots else '-'}",
+        "출처: ECB 기준환율 (Frankfurter API)",
+        DISCLAIMER,
+    ]
+    return "\n".join(lines)
+
+
+def html_body(
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    cids: list[str],
+) -> str:
+    """카드 이미지를 세로로 이어 붙인 단순한 HTML. 메일 클라이언트 호환성을 위해 인라인 스타일만 쓴다."""
+    images = "".join(
+        f'<img src="cid:{cid[1:-1]}" width="600" '
+        'style="display:block;width:100%;max-width:600px;height:auto;'
+        'border-radius:12px;margin:0 0 16px 0;" alt="주간 환율 카드뉴스">'
+        for cid in cids
+    )
+    rows = "".join(
+        f'<tr>'
+        f'<td style="padding:8px 0;color:#8A99B8;font-size:14px;">{s.display_name}</td>'
+        f'<td style="padding:8px 0;color:#F2F5FA;font-size:14px;text-align:right;">{s.latest:,.2f}원</td>'
+        f'<td style="padding:8px 0;font-size:14px;text-align:right;'
+        f'color:{"#FF5C5C" if s.direction == "up" else "#4D8DFF" if s.direction == "down" else "#8A99B8"};">'
+        f'{_sign(s.week.pct) + "%" if s.week else "-"}</td>'
+        f'</tr>'
+        for s in snapshots
+    )
+    return f"""<!DOCTYPE html>
+<html lang="ko"><body style="margin:0;padding:24px 12px;background:#0B1220;">
+<div style="max-width:600px;margin:0 auto;font-family:'Apple SD Gothic Neo','Malgun Gothic',sans-serif;">
+  <p style="color:#FFC24B;font-size:13px;letter-spacing:2px;margin:0 0 4px;">WEEKLY FX BRIEF</p>
+  <h1 style="color:#F2F5FA;font-size:24px;margin:0 0 6px;">주간 환율 브리핑</h1>
+  <p style="color:#8A99B8;font-size:14px;margin:0 0 20px;">{issued.strftime('%Y년 %m월 %d일')} 발행</p>
+  <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">{rows}</table>
+  {images}
+  <p style="color:#8A99B8;font-size:12px;line-height:1.6;margin-top:24px;">
+    출처: ECB 기준환율 (Frankfurter API)<br>{DISCLAIMER}
+  </p>
+</div></body></html>"""
+
+
+def build_message(
+    config: MailConfig,
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    card_paths: list[Path],
+) -> EmailMessage:
+    message = EmailMessage()
+    message["Subject"] = subject_line(commentary, issued)
+    message["From"] = f"{config.sender_name} <{config.user}>"
+    message["To"] = ", ".join(config.recipients)
+
+    message.set_content(plain_body(snapshots, commentary, issued))
+
+    cids = [make_msgid(domain="fx.newsletter") for _ in card_paths]
+    message.add_alternative(html_body(snapshots, commentary, issued, cids), subtype="html")
+
+    # add_alternative 뒤의 마지막 파트가 HTML 파트다. 여기에 이미지를 related로 붙인다.
+    html_part = message.get_payload()[-1]
+    for path, cid in zip(card_paths, cids):
+        mime, _ = mimetypes.guess_type(path.name)
+        maintype, subtype = (mime or "image/png").split("/", 1)
+        html_part.add_related(
+            path.read_bytes(),
+            maintype=maintype,
+            subtype=subtype,
+            cid=cid,
+            filename=path.name,
+        )
+    return message
+
+
+def send(config: MailConfig, message: EmailMessage) -> None:
+    missing = config.validate()
+    if missing:
+        raise RuntimeError("메일 설정이 비어 있습니다: " + ", ".join(missing))
+
+    if config.port == 587:
+        with smtplib.SMTP(config.host, config.port, timeout=60) as server:
+            server.starttls()
+            server.login(config.user, config.password)
+            server.send_message(message)
+    else:
+        with smtplib.SMTP_SSL(config.host, config.port, timeout=60) as server:
+            server.login(config.user, config.password)
+            server.send_message(message)
+    log.info("메일 발송 완료 -> %s", ", ".join(config.recipients))

--- a/tools/fx_newsletter/main.py
+++ b/tools/fx_newsletter/main.py
@@ -1,0 +1,122 @@
+"""주간 환율 카드뉴스 파이프라인 진입점.
+
+  python -m fx_newsletter.main --dry-run      # 카드만 렌더링하고 저장
+  python -m fx_newsletter.main                # 렌더링 후 메일 발송
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import sys
+from pathlib import Path
+
+from . import cards, commentary as commentary_mod, fetch, indicators, mailer
+from .config import HISTORY_DAYS, MailConfig
+
+log = logging.getLogger("fx_newsletter")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="주간 환율 카드뉴스 생성 및 발송")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="메일을 보내지 않고 카드 이미지만 만든다",
+    )
+    parser.add_argument(
+        "--no-ai",
+        action="store_true",
+        help="Claude 해설을 건너뛰고 규칙 기반 문장만 쓴다",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("build/fx-cards"),
+        help="카드 PNG를 저장할 디렉터리 (기본: build/fx-cards)",
+    )
+    parser.add_argument(
+        "--date",
+        type=dt.date.fromisoformat,
+        default=None,
+        help="발행 기준일 (YYYY-MM-DD). 기본은 오늘",
+    )
+    return parser.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> int:
+    issued = args.date or dt.date.today()
+
+    log.info("환율 시계열 수집 중 (기준일 %s, %d일치)", issued, HISTORY_DAYS)
+    series_map = fetch.load_series(issued, HISTORY_DAYS)
+
+    snapshots = indicators.build_snapshots(series_map)
+    if not snapshots:
+        log.error("계산된 스냅샷이 없습니다.")
+        return 1
+    log.info("지표 계산 완료: %s", ", ".join(s.display_name for s in snapshots))
+
+    note = commentary_mod.build(snapshots, use_ai=not args.no_ai)
+    log.info("해설 생성 완료 (source=%s): %s", note.source, note.headline)
+
+    card_paths = cards.render_all(snapshots, note, issued, args.out)
+    log.info("카드 %d장 생성 -> %s", len(card_paths), args.out)
+
+    summary_path = args.out / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "issued": issued.isoformat(),
+                "commentary": note.to_dict(),
+                "pairs": [
+                    {
+                        "code": s.code,
+                        "display_name": s.display_name,
+                        "latest": round(s.latest, 4),
+                        "latest_date": s.latest_date.isoformat(),
+                        "week_pct": round(s.week.pct, 4) if s.week else None,
+                        "trend": s.trend,
+                    }
+                    for s in snapshots
+                ],
+                "cards": [p.name for p in card_paths],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    if args.dry_run:
+        log.info("--dry-run 이므로 메일은 보내지 않습니다.")
+        return 0
+
+    config = MailConfig.from_env()
+    missing = config.validate()
+    if missing:
+        log.error("메일 설정 누락: %s", ", ".join(missing))
+        return 2
+
+    message = mailer.build_message(config, snapshots, note, issued, card_paths)
+    mailer.send(config, message)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    args = parse_args(argv)
+    try:
+        return run(args)
+    except Exception as exc:
+        log.error("실패: %s: %s", type(exc).__name__, exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fx_newsletter/requirements.txt
+++ b/tools/fx_newsletter/requirements.txt
@@ -1,0 +1,3 @@
+Pillow>=10.0,<13
+requests>=2.31,<3
+anthropic>=0.40

--- a/tools/fx_newsletter/tests/fixtures.py
+++ b/tools/fx_newsletter/tests/fixtures.py
@@ -1,0 +1,35 @@
+"""테스트와 오프라인 미리보기가 공유하는 합성 데이터."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+
+def synthetic_payload(end: dt.date, days: int = 320, seed: float = 0.0) -> dict:
+    """Frankfurter의 EUR 기준 시계열 응답을 흉내 낸다.
+
+    실제 응답처럼 주말은 비워 두고, 통화마다 다른 주기의 사인파를 겹쳐
+    상승·하락·횡보가 모두 나오도록 만든다.
+    """
+    rates: dict[str, dict[str, float]] = {}
+    day = end - dt.timedelta(days=days)
+    step = 0
+    while day <= end:
+        if day.weekday() < 5:  # 주말 고시 없음
+            t = step + seed
+            rates[day.isoformat()] = {
+                "KRW": 1450 + 60 * math.sin(t / 47) + 8 * math.sin(t / 5),
+                "USD": 1.08 + 0.05 * math.sin(t / 61),
+                "JPY": 168 + 9 * math.sin(t / 39 + 1.2),
+                "CNY": 7.8 + 0.25 * math.sin(t / 55 + 2.4),
+            }
+            step += 1
+        day += dt.timedelta(days=1)
+    return {
+        "amount": 1.0,
+        "base": "EUR",
+        "start_date": (end - dt.timedelta(days=days)).isoformat(),
+        "end_date": end.isoformat(),
+        "rates": rates,
+    }

--- a/tools/fx_newsletter/tests/test_pipeline.py
+++ b/tools/fx_newsletter/tests/test_pipeline.py
@@ -1,0 +1,223 @@
+"""네트워크 없이 파이프라인 전 구간을 검증한다."""
+
+from __future__ import annotations
+
+import datetime as dt
+import tempfile
+import unittest
+from pathlib import Path
+
+from fx_newsletter import cards, commentary, fetch, indicators, mailer
+from fx_newsletter.config import MailConfig
+from fx_newsletter.tests.fixtures import synthetic_payload
+
+END = dt.date(2026, 9, 4)  # 금요일
+
+
+class FetchTest(unittest.TestCase):
+    def test_converts_eur_base_to_krw_pairs(self):
+        payload = {
+            "base": "EUR",
+            "rates": {"2026-09-04": {"KRW": 1450.0, "USD": 1.10, "JPY": 160.0, "CNY": 7.25}},
+        }
+        # 관측치가 1건이면 시계열이 너무 짧다고 거부해야 한다.
+        with self.assertRaises(fetch.FetchError):
+            fetch.to_series(payload)
+
+        payload["rates"]["2026-09-03"] = {"KRW": 1440.0, "USD": 1.10, "JPY": 160.0, "CNY": 7.25}
+        series = fetch.to_series(payload)
+
+        self.assertAlmostEqual(series["USD"].latest, 1450.0 / 1.10, places=6)
+        self.assertAlmostEqual(series["EUR"].latest, 1450.0, places=6)
+        # 엔화는 100엔 기준으로 표시한다.
+        self.assertAlmostEqual(series["JPY"].latest, 100 * 1450.0 / 160.0, places=6)
+        self.assertAlmostEqual(series["CNY"].latest, 1450.0 / 7.25, places=6)
+        self.assertEqual(series["JPY"].pair.display_name, "100JPY/KRW")
+
+    def test_skips_days_with_missing_currency(self):
+        payload = {
+            "base": "EUR",
+            "rates": {
+                "2026-09-02": {"KRW": 1430.0, "USD": 1.10, "JPY": 160.0, "CNY": 7.25},
+                "2026-09-03": {"USD": 1.10, "JPY": 160.0, "CNY": 7.25},  # KRW 결측
+                "2026-09-04": {"KRW": 1450.0, "USD": 1.10, "JPY": 160.0, "CNY": 7.25},
+            },
+        }
+        series = fetch.to_series(payload)
+        self.assertEqual(series["USD"].dates, (dt.date(2026, 9, 2), dt.date(2026, 9, 4)))
+
+    def test_falls_back_to_second_host(self):
+        seen: list[str] = []
+
+        def flaky_get(url: str) -> dict:
+            seen.append(url)
+            if "frankfurter.dev" in url:
+                raise RuntimeError("gateway 403")
+            return synthetic_payload(END, days=40)
+
+        payload = fetch.fetch_raw(END - dt.timedelta(days=40), END, session_get=flaky_get)
+        self.assertTrue(payload["rates"])
+        self.assertEqual(len(seen), 2)
+        # 기준통화 EUR은 symbols에서 빠져야 한다.
+        self.assertIn("symbols=CNY,JPY,KRW,USD", seen[0])
+
+    def test_raises_when_all_hosts_fail(self):
+        def always_fail(url: str) -> dict:
+            raise RuntimeError("down")
+
+        with self.assertRaises(fetch.FetchError):
+            fetch.fetch_raw(END - dt.timedelta(days=40), END, session_get=always_fail)
+
+
+class IndicatorTest(unittest.TestCase):
+    def test_sma_and_change_lookup_span_weekends(self):
+        series = fetch.to_series(synthetic_payload(END))["USD"]
+        snapshot = indicators.build_snapshot(series)
+
+        self.assertEqual(snapshot.latest_date, END)
+        self.assertIsNotNone(snapshot.week)
+        # 금요일 기준 7일 전은 지난 금요일(고시 있는 날)이어야 한다.
+        self.assertEqual(snapshot.week.ref_date, dt.date(2026, 8, 28))
+        self.assertAlmostEqual(snapshot.sma20, sum(series.values[-20:]) / 20, places=6)
+        self.assertAlmostEqual(snapshot.sma60, sum(series.values[-60:]) / 60, places=6)
+        self.assertLessEqual(snapshot.latest, snapshot.high52)
+        self.assertGreaterEqual(snapshot.latest, snapshot.low52)
+        self.assertEqual(len(snapshot.spark), 60)
+
+    def test_rsi_bounds(self):
+        rising = tuple(float(100 + i) for i in range(40))
+        falling = tuple(float(140 - i) for i in range(40))
+        self.assertAlmostEqual(indicators.rsi(rising), 100.0, places=6)
+        self.assertAlmostEqual(indicators.rsi(falling), 0.0, places=6)
+        self.assertIsNone(indicators.rsi((1.0, 2.0)))
+
+    def test_flat_series_has_no_volatility_and_neutral_position(self):
+        flat = tuple(1000.0 for _ in range(40))
+        self.assertAlmostEqual(indicators.annualized_volatility(flat), 0.0, places=9)
+        # 표준편차가 0이면 볼린저 폭이 0이라 위치를 정의할 수 없다.
+        self.assertIsNone(indicators.bollinger_pct(flat))
+
+    def test_bollinger_within_range_for_normal_series(self):
+        series = fetch.to_series(synthetic_payload(END))["EUR"]
+        value = indicators.bollinger_pct(series.values)
+        self.assertIsNotNone(value)
+        self.assertGreater(value, -50)
+        self.assertLess(value, 150)
+
+    def test_trend_labels(self):
+        self.assertEqual(indicators._trend_label(110, 105, 100), "상승 추세")
+        self.assertEqual(indicators._trend_label(90, 95, 100), "하락 추세")
+        self.assertEqual(indicators._trend_label(100, 105, 100), "상승 속 조정")
+        self.assertEqual(indicators._trend_label(100, 95, 100), "하락 속 반등")
+        self.assertEqual(indicators._trend_label(100, None, None), "판단 보류")
+
+
+class CommentaryTest(unittest.TestCase):
+    def setUp(self):
+        series_map = fetch.to_series(synthetic_payload(END))
+        self.snapshots = indicators.build_snapshots(series_map)
+
+    def test_rule_based_covers_every_pair(self):
+        note = commentary.rule_based(self.snapshots)
+        self.assertEqual(note.source, "rules")
+        self.assertEqual(set(note.pair_comments), {"USD", "JPY", "EUR", "CNY"})
+        self.assertTrue(note.headline)
+        self.assertTrue(note.summary)
+        self.assertEqual(len(note.watchpoints), 3)
+
+    def test_build_uses_rules_when_ai_disabled(self):
+        self.assertEqual(commentary.build(self.snapshots, use_ai=False).source, "rules")
+
+    def test_build_falls_back_when_claude_raises(self):
+        original = commentary._call_claude
+        commentary._call_claude = lambda snapshots: (_ for _ in ()).throw(RuntimeError("boom"))
+        try:
+            import os
+
+            os.environ["ANTHROPIC_API_KEY"] = "test-key"
+            note = commentary.build(self.snapshots, use_ai=True)
+        finally:
+            commentary._call_claude = original
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+        self.assertEqual(note.source, "rules")
+
+    def test_payload_has_no_raw_series(self):
+        payload = commentary.snapshots_to_payload(self.snapshots)
+        self.assertEqual(len(payload), 4)
+        self.assertNotIn("spark", payload[0])
+
+
+class RenderAndMailTest(unittest.TestCase):
+    def setUp(self):
+        series_map = fetch.to_series(synthetic_payload(END))
+        self.snapshots = indicators.build_snapshots(series_map)
+        self.note = commentary.rule_based(self.snapshots)
+
+    def test_renders_one_card_per_pair_plus_cover_and_outlook(self):
+        from PIL import Image
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            self.assertEqual(len(paths), len(self.snapshots) + 2)
+            for path in paths:
+                self.assertTrue(path.exists())
+                with Image.open(path) as image:
+                    self.assertEqual(image.size, (1080, 1080))
+            self.assertEqual(paths[0].name, "01-cover.png")
+            self.assertEqual(paths[-1].name, "06-outlook.png")
+
+    def test_message_embeds_every_card_inline(self):
+        config = MailConfig(
+            host="smtp.gmail.com",
+            port=465,
+            user="me@example.com",
+            password="app pass word",
+            sender_name="주간 환율 브리핑",
+            recipients=("me@example.com",),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            message = mailer.build_message(config, self.snapshots, self.note, END, paths)
+
+        self.assertIn(self.note.headline, message["Subject"])
+        self.assertEqual(message["To"], "me@example.com")
+
+        html_parts = [p for p in message.walk() if p.get_content_type() == "text/html"]
+        images = [p for p in message.walk() if p.get_content_type() == "image/png"]
+        self.assertEqual(len(html_parts), 1)
+        self.assertEqual(len(images), len(paths))
+
+        html = html_parts[0].get_content()
+        for part in images:
+            cid = part["Content-ID"].strip("<>")
+            self.assertIn(f"cid:{cid}", html)
+
+        plain = [p for p in message.walk() if p.get_content_type() == "text/plain"][0].get_content()
+        self.assertIn("주간 환율 브리핑", plain)
+        for snapshot in self.snapshots:
+            self.assertIn(snapshot.display_name, plain)
+
+    def test_mail_config_strips_app_password_spaces(self):
+        import os
+
+        os.environ.update(
+            {"FX_SMTP_USER": "a@b.com", "FX_SMTP_PASSWORD": "abcd efgh ijkl mnop"}
+        )
+        try:
+            config = MailConfig.from_env()
+        finally:
+            for key in ("FX_SMTP_USER", "FX_SMTP_PASSWORD"):
+                os.environ.pop(key, None)
+        self.assertEqual(config.password, "abcdefghijklmnop")
+        self.assertEqual(config.recipients, ("a@b.com",))
+        self.assertEqual(config.validate(), [])
+
+    def test_mail_config_reports_missing_fields(self):
+        config = MailConfig("h", 465, "", "", "n", ())
+        self.assertEqual(
+            set(config.validate()), {"FX_SMTP_USER", "FX_SMTP_PASSWORD", "FX_MAIL_TO"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

매주 원화 환율 4종(USD/KRW, 100JPY/KRW, EUR/KRW, CNY/KRW)을 정리해 카드뉴스 PNG 6장을 만들고 Gmail로 보내는 파이프라인을 추가했습니다. GitHub Actions 크론(일요일 23:00 UTC = 월요일 08:00 KST)으로 돌아가며 별도 서버가 필요 없습니다.

### 추가된 것

| 경로 | 역할 |
|---|---|
| `tools/fx_newsletter/fetch.py` | Frankfurter(ECB 기준환율)에서 EUR 기준 시계열을 **1회** 요청해 KRW 대비로 환산 |
| `tools/fx_newsletter/indicators.py` | 20/60일 이동평균, 연율 변동성, RSI(14), 볼린저 %B, 52주 고저, 추세 판정 |
| `tools/fx_newsletter/commentary.py` | Claude로 한국어 해설 생성 + 지표 기반 규칙 문장 대체 |
| `tools/fx_newsletter/cards.py` | Pillow로 1080×1080 카드 렌더링 |
| `tools/fx_newsletter/mailer.py` | 카드를 cid로 인라인 삽입한 HTML + 동일 내용 텍스트 본문 조립, SMTP 발송 |
| `tools/fx_newsletter/main.py` | 파이프라인 진입점 (`--dry-run`, `--no-ai`, `--out`, `--date`) |
| `.github/workflows/fx-newsletter.yml` | 주간 크론 + 수동 실행(dry-run 토글), 카드 아티팩트 업로드 |

기존 Jekyll 사이트 파일은 건드리지 않았습니다. `.gitignore`에 생성물 디렉터리 `build/`만 추가했습니다.

### 설계 판단

**ECB 기준환율을 선택** — 무료·API 키 불필요·과거 시계열 제공 조건을 모두 만족하는 소스입니다. ECB가 EUR 기준으로 고시하므로 EUR 기준 시계열을 한 번만 받아 KRW 대비로 환산합니다. 주당 API 호출이 1회로 끝나고, 모든 통화가 같은 고시일 집합을 공유해 날짜 정렬 문제가 없습니다.

다만 서울 외환시장 종가나 은행 매매기준율과는 소수점 아래에서 차이가 납니다. 추세 파악용이지 환전 금액 계산용이 아니라는 점을 README와 모든 카드 하단에 명시했습니다.

**실패 처리를 두 갈래로 분리** — Claude 호출이 실패하거나 키가 없으면 지표 기반 문장으로 조용히 대체되어 뉴스레터는 나갑니다. 반면 환율 데이터를 못 받으면 실패로 끝냅니다. 틀린 숫자를 보내는 것보다 안 보내는 편이 낫다고 판단했습니다.

**주간 등락을 달력 날짜로 계산** — ECB는 영업일에만 고시해 관측치가 주 5개입니다. "관측치 5개 전"으로 세면 공휴일에 기준이 어긋나므로, 7일 전 이하의 가장 최근 고시를 되짚어 찾는 방식으로 했습니다.

**한글 폰트 탐색을 다단계로** — 나눔고딕 → Noto CJK → WQY Zen Hei → DejaVu 순으로 찾고, 못 찾으면 기본 폰트로 떨어지되 경고를 남깁니다. CI에서는 `fonts-nanum`을 설치합니다.

### 검증

- 테스트 17건 통과 (`python -m unittest discover -s fx_newsletter/tests -t .`). 합성 시계열로 네트워크 없이 환산·지표·렌더링·메일 조립 전 구간을 검증합니다.
- 카드 6장을 실제로 렌더링해 레이아웃과 한글 표시를 육안 확인했습니다.

**확인하지 못한 부분:** 개발 환경의 네트워크 정책이 외부 API를 차단해(게이트웨이 403) 실제 Frankfurter 호출은 검증하지 못했습니다. 스키마는 안정적인 형태이고 호스트 2곳 폴백과 지수 백오프 재시도를 넣었지만, 머지 후 첫 실행은 `dry_run`으로 돌려 보길 권합니다.

## Context

관련 이슈 없음. 사용자 요청으로 새로 만든 기능입니다.

머지 후 필요한 설정:

1. 저장소 Secrets 등록 — `FX_SMTP_USER`, `FX_SMTP_PASSWORD`(Gmail 앱 비밀번호 16자리), `FX_MAIL_TO`(선택), `ANTHROPIC_API_KEY`(선택)
2. 포크 저장소이므로 Actions 탭에서 워크플로 실행을 한 번 허용해야 할 수 있음
3. Actions 탭에서 `dry_run`을 켜고 수동 실행해 카드 아티팩트를 먼저 확인

자세한 설정 절차는 `tools/fx_newsletter/README.md`에 정리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUCTgJeMCANirJRLFeRGV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUCTgJeMCANirJRLFeRGV2)_