### PR TITLE
메일 발송 수단으로 Resend 추가하고 기본값으로 삼음

### DIFF
--- a/.github/workflows/fx-newsletter.yml
+++ b/.github/workflows/fx-newsletter.yml
@@ -54,9 +54,12 @@ jobs:
       - name: 카드 생성 및 발송
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # 발송 수단: RESEND_API_KEY가 있으면 Resend, 없으면 Gmail SMTP.
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          FX_MAIL_FROM: ${{ secrets.FX_MAIL_FROM }}
+          FX_MAIL_TO: ${{ secrets.FX_MAIL_TO }}
           FX_SMTP_USER: ${{ secrets.FX_SMTP_USER }}
           FX_SMTP_PASSWORD: ${{ secrets.FX_SMTP_PASSWORD }}
-          FX_MAIL_TO: ${{ secrets.FX_MAIL_TO }}
         run: |
           python -m fx_newsletter.main \
             --out "$GITHUB_WORKSPACE/build/fx-cards" \

--- a/tools/fx_newsletter/README.md
+++ b/tools/fx_newsletter/README.md
@@ -5,7 +5,7 @@ GitHub Actions에서 돌아가므로 별도 서버가 필요 없다.
 
 ## 무엇이 오는가
 
-카드 6장이 메일 본문에 인라인으로 들어온다.
+카드 6장이 메일 본문에 인라인으로 들어온다 (인라인이 불가하면 첨부로 들어온다).
 
 | 순서 | 카드 | 내용 |
 |---|---|---|
@@ -32,26 +32,49 @@ ECB는 EUR 기준으로 고시하므로 EUR 기준 시계열을 한 번만 받�
 
 ## 설정
 
-### 1. GitHub Secrets 등록
+### 1. 발송 수단 고르기
+
+두 가지 중 하나를 고른다. `RESEND_API_KEY`가 등록돼 있으면 Resend를 쓰고,
+없으면 Gmail SMTP로 떨어진다.
+
+| | Resend (권장) | Gmail SMTP |
+|---|---|---|
+| 등록할 열쇠 | API 키 | 앱 비밀번호 |
+| 그 열쇠의 권한 | **발송만** | 발송 + **받은편지함 읽기** |
+| 추가 가입 | 필요 | 불필요 |
+
+받은편지함 읽기 권한까지 넘기지 않아도 되므로 Resend를 권한다.
+
+### 2. GitHub Secrets 등록
 
 저장소 → Settings → Secrets and variables → Actions → New repository secret.
 
+**Resend를 쓸 때**
+
 | 이름 | 필수 | 설명 |
 |---|---|---|
-| `FX_SMTP_USER` | ✅ | 보내는 Gmail 주소 (예: `you@gmail.com`) |
-| `FX_SMTP_PASSWORD` | ✅ | Gmail **앱 비밀번호** 16자리 (계정 비밀번호 아님) |
-| `FX_MAIL_TO` | | 받는 주소. 생략하면 `FX_SMTP_USER`로 보냄. 쉼표로 여러 명 지정 가능 |
-| `ANTHROPIC_API_KEY` | | 있으면 Claude가 해설을 쓴다. 없으면 지표 기반 문장으로 자동 대체 |
+| `RESEND_API_KEY` | ✅ | Resend 대시보드에서 발급한 `re_`로 시작하는 키 |
+| `FX_MAIL_TO` | ✅ | 받는 주소. 쉼표로 여러 명 지정 가능 |
+| `FX_MAIL_FROM` | | 보내는 주소. 생략하면 `onboarding@resend.dev` |
+| `ANTHROPIC_API_KEY` | | 있으면 Claude가 해설을 쓴다. 없으면 지표 기반 문장으로 대체 |
 
-### 2. Gmail 앱 비밀번호 발급
+> 도메인을 등록하지 않았다면 `onboarding@resend.dev`가 기본 발신 주소가 된다.
+> 이 주소는 **Resend 계정에 등록한 본인 메일로만** 보낼 수 있다. 다른 주소로
+> 보내려면 Resend에 도메인을 등록하고 `FX_MAIL_FROM`을 그 도메인 주소로 지정한다.
+
+**Gmail SMTP를 쓸 때**
+
+| 이름 | 필수 | 설명 |
+|---|---|---|
+| `FX_SMTP_USER` | ✅ | 보내는 Gmail 주소 |
+| `FX_SMTP_PASSWORD` | ✅ | Gmail **앱 비밀번호** 16자리 (계정 비밀번호 아님) |
+| `FX_MAIL_TO` | | 생략하면 `FX_SMTP_USER`로 보냄 |
+| `ANTHROPIC_API_KEY` | | 위와 같음 |
 
 앱 비밀번호는 2단계 인증이 켜져 있어야 만들 수 있다.
-
-1. [Google 계정 보안](https://myaccount.google.com/security)에서 2단계 인증을 켠다.
-2. [앱 비밀번호](https://myaccount.google.com/apppasswords)로 이동한다.
-3. 앱 이름을 아무거나 (예: `fx-newsletter`) 적고 생성한다.
-4. 나온 16자리를 `FX_SMTP_PASSWORD`에 넣는다. 표시된 공백은 넣어도 되고 안 넣어도 된다
-   (코드에서 공백을 제거한다).
+[Google 계정 보안](https://myaccount.google.com/security)에서 2단계 인증을 켠 뒤
+[앱 비밀번호](https://myaccount.google.com/apppasswords)에서 발급한다. 표시된
+공백은 넣어도 되고 안 넣어도 된다 (코드에서 제거한다).
 
 ### 3. Actions 활성화 확인
 
@@ -90,10 +113,14 @@ sudo apt-get install -y fonts-nanum        # 한글 폰트. macOS는 기본 폰�
 python -m fx_newsletter.main --dry-run --out build/fx-cards
 
 # 실제 발송
-export FX_SMTP_USER=you@gmail.com
-export FX_SMTP_PASSWORD='앱비밀번호16자리'
+export RESEND_API_KEY=re_...
+export FX_MAIL_TO=you@gmail.com
 export ANTHROPIC_API_KEY=sk-ant-...
 python -m fx_newsletter.main
+
+# Gmail SMTP로 보내려면 RESEND_API_KEY 대신
+export FX_SMTP_USER=you@gmail.com
+export FX_SMTP_PASSWORD='앱비밀번호16자리'
 ```
 
 주요 옵션:
@@ -123,7 +150,7 @@ tools/fx_newsletter/
 ├── indicators.py   이동평균 · RSI · 볼린저 · 변동성 · 추세 판정
 ├── commentary.py   Claude 해설 생성 + 규칙 기반 대체
 ├── cards.py        Pillow로 1080x1080 PNG 렌더링
-├── mailer.py       인라인 이미지 메일 조립 및 SMTP 발송
+├── mailer.py       메일 본문 조립, Resend·SMTP 발송
 └── main.py         파이프라인 진입점 (CLI)
 ```
 
@@ -133,6 +160,8 @@ tools/fx_newsletter/
   지수 백오프로 재시도한다.
 - Claude 호출이 실패하거나 키가 없으면 지표 기반 문장으로 조용히 대체된다.
   해설이 밋밋해질 뿐 뉴스레터는 나간다.
+- Resend가 인라인 이미지(`content_id`) 요청을 거부하면 첨부 전용으로 한 번
+  다시 보낸다. 카드가 본문에 안 박히는 것보다 메일이 아예 안 가는 쪽이 나쁘다.
 
 반대로 환율 데이터를 아예 못 받으면 그때는 실패로 끝낸다. 틀린 숫자를 보내느니
 안 보내는 편이 낫기 때문이다.
@@ -152,7 +181,7 @@ Claude 해설이 그 통화까지 써 준다.
 ## 비용
 
 - 환율 데이터: 무료
-- Gmail 발송: 무료
+- 메일 발송: Resend 무료 티어 또는 Gmail 모두 이 사용량(주 1통)에서는 무료
 - GitHub Actions: 퍼블릭 저장소 무료. 1회 실행 약 1~2분
 - Claude API: 주 1회, 입력 2천 토큰 안팎의 짧은 호출이라 월 단위로도 소액이다
 

--- a/tools/fx_newsletter/config.py
+++ b/tools/fx_newsletter/config.py
@@ -44,36 +44,73 @@ def _env(name: str, default: str = "") -> str:
 
 @dataclass(frozen=True)
 class MailConfig:
-    """Gmail SMTP 발송 설정."""
+    """메일 발송 설정.
 
-    host: str
-    port: int
-    user: str
-    password: str
+    발송 수단은 두 가지다. RESEND_API_KEY가 있으면 Resend를 쓰고, 없으면
+    Gmail SMTP로 떨어진다. Resend 키는 '보내기'만 할 수 있어 받은편지함을
+    읽지 못하므로, 지메일 앱 비밀번호보다 권한이 좁다.
+    """
+
+    provider: str          # "resend" 또는 "smtp"
     sender_name: str
+    sender_address: str
     recipients: tuple[str, ...]
+
+    # Resend 경로
+    resend_api_key: str = ""
+
+    # SMTP 경로
+    host: str = ""
+    port: int = 465
+    user: str = ""
+    password: str = ""
 
     @classmethod
     def from_env(cls) -> "MailConfig":
-        user = _env("FX_SMTP_USER")
-        raw_to = _env("FX_MAIL_TO") or user
+        resend_key = _env("RESEND_API_KEY")
+        smtp_user = _env("FX_SMTP_USER")
+        provider = "resend" if resend_key else "smtp"
+
+        # Resend는 발신 주소를 직접 정해야 한다. 도메인을 등록하지 않았다면
+        # Resend가 주는 테스트 발신 주소를 쓰되, 그 경우 계정 소유자 본인
+        # 주소로만 보낼 수 있다.
+        default_sender = "onboarding@resend.dev" if provider == "resend" else smtp_user
+        sender_address = _env("FX_MAIL_FROM", default_sender)
+
+        raw_to = _env("FX_MAIL_TO") or smtp_user
         recipients = tuple(a.strip() for a in raw_to.split(",") if a.strip())
+
         return cls(
+            provider=provider,
+            sender_name=_env("FX_MAIL_FROM_NAME", "주간 환율 브리핑"),
+            sender_address=sender_address,
+            recipients=recipients,
+            resend_api_key=resend_key,
             host=_env("FX_SMTP_HOST", "smtp.gmail.com"),
             port=int(_env("FX_SMTP_PORT", "465")),
-            user=user,
+            user=smtp_user,
             # Gmail 앱 비밀번호는 표시할 때 4자씩 띄어쓰기가 들어가므로 공백을 지운다.
             password=_env("FX_SMTP_PASSWORD").replace(" ", ""),
-            sender_name=_env("FX_MAIL_FROM_NAME", "주간 환율 브리핑"),
-            recipients=recipients,
         )
 
+    @property
+    def from_header(self) -> str:
+        return f"{self.sender_name} <{self.sender_address}>"
+
     def validate(self) -> list[str]:
+        """부족한 환경 변수 이름을 돌려준다. 비어 있으면 발송 가능하다."""
         missing = []
-        if not self.user:
-            missing.append("FX_SMTP_USER")
-        if not self.password:
-            missing.append("FX_SMTP_PASSWORD")
         if not self.recipients:
             missing.append("FX_MAIL_TO")
+        if not self.sender_address:
+            missing.append("FX_MAIL_FROM")
+
+        if self.provider == "resend":
+            if not self.resend_api_key:
+                missing.append("RESEND_API_KEY")
+        else:
+            if not self.user:
+                missing.append("FX_SMTP_USER")
+            if not self.password:
+                missing.append("FX_SMTP_PASSWORD")
         return missing

--- a/tools/fx_newsletter/mailer.py
+++ b/tools/fx_newsletter/mailer.py
@@ -1,7 +1,18 @@
-"""카드 PNG를 본문에 삽입한 메일을 Gmail SMTP로 보낸다."""
+"""카드 PNG를 담은 메일을 조립하고 발송한다.
+
+발송 수단은 두 가지다.
+
+- Resend (권장): HTTPS API. 키가 '보내기' 권한만 가지므로 받은편지함을
+  읽을 수 없다.
+- Gmail SMTP: 앱 비밀번호로 로그인. 추가 가입은 없지만 그 비밀번호는
+  메일 읽기 권한까지 포함한다.
+
+둘 다 같은 본문(HTML + 텍스트)과 같은 카드 이미지를 쓴다.
+"""
 
 from __future__ import annotations
 
+import base64
 import datetime as dt
 import logging
 import mimetypes
@@ -10,11 +21,20 @@ from email.message import EmailMessage
 from email.utils import make_msgid
 from pathlib import Path
 
+import requests
+
 from .commentary import DISCLAIMER, Commentary
 from .config import MailConfig
 from .indicators import PairSnapshot
 
 log = logging.getLogger(__name__)
+
+RESEND_ENDPOINT = "https://api.resend.com/emails"
+RESEND_TIMEOUT = 60
+
+
+class SendError(RuntimeError):
+    """메일을 보내지 못했을 때."""
 
 
 def subject_line(commentary: Commentary, issued: dt.date) -> str:
@@ -58,14 +78,24 @@ def html_body(
     snapshots: list[PairSnapshot],
     commentary: Commentary,
     issued: dt.date,
-    cids: list[str],
+    image_srcs: list[str],
 ) -> str:
-    """카드 이미지를 세로로 이어 붙인 단순한 HTML. 메일 클라이언트 호환성을 위해 인라인 스타일만 쓴다."""
+    """카드 이미지를 세로로 이어 붙인 HTML.
+
+    image_srcs가 비어 있으면 이미지 태그 없이 표만 넣는다. 이 경우 카드는
+    첨부파일로만 전달된다.
+    """
     images = "".join(
-        f'<img src="cid:{cid[1:-1]}" width="600" '
+        f'<img src="{src}" width="600" '
         'style="display:block;width:100%;max-width:600px;height:auto;'
         'border-radius:12px;margin:0 0 16px 0;" alt="주간 환율 카드뉴스">'
-        for cid in cids
+        for src in image_srcs
+    )
+    note = (
+        ""
+        if image_srcs
+        else '<p style="color:#8A99B8;font-size:13px;margin:0 0 16px;">'
+        "카드 이미지는 이 메일의 첨부파일로 들어 있습니다.</p>"
     )
     rows = "".join(
         f'<tr>'
@@ -84,12 +114,107 @@ def html_body(
   <h1 style="color:#F2F5FA;font-size:24px;margin:0 0 6px;">주간 환율 브리핑</h1>
   <p style="color:#8A99B8;font-size:14px;margin:0 0 20px;">{issued.strftime('%Y년 %m월 %d일')} 발행</p>
   <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">{rows}</table>
-  {images}
+  {note}{images}
   <p style="color:#8A99B8;font-size:12px;line-height:1.6;margin-top:24px;">
     출처: ECB 기준환율 (Frankfurter API)<br>{DISCLAIMER}
   </p>
 </div></body></html>"""
 
+
+# --------------------------------------------------------------------------
+# Resend
+# --------------------------------------------------------------------------
+
+def _cid_for(path: Path) -> str:
+    return f"card-{path.stem}"
+
+
+def resend_payload(
+    config: MailConfig,
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    card_paths: list[Path],
+    inline: bool,
+) -> dict:
+    """Resend API 요청 본문.
+
+    inline=True면 첨부에 content_id를 달고 HTML에서 cid:로 참조한다.
+    inline=False면 순수 첨부로만 보낸다.
+    """
+    attachments = []
+    for path in card_paths:
+        mime, _ = mimetypes.guess_type(path.name)
+        attachment = {
+            "filename": path.name,
+            "content": base64.b64encode(path.read_bytes()).decode("ascii"),
+            "content_type": mime or "image/png",
+        }
+        if inline:
+            attachment["content_id"] = _cid_for(path)
+        attachments.append(attachment)
+
+    srcs = [f"cid:{_cid_for(p)}" for p in card_paths] if inline else []
+    return {
+        "from": config.from_header,
+        "to": list(config.recipients),
+        "subject": subject_line(commentary, issued),
+        "html": html_body(snapshots, commentary, issued, srcs),
+        "text": plain_body(snapshots, commentary, issued),
+        "attachments": attachments,
+    }
+
+
+def _post_resend(api_key: str, payload: dict) -> requests.Response:
+    return requests.post(
+        RESEND_ENDPOINT,
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        timeout=RESEND_TIMEOUT,
+    )
+
+
+def send_via_resend(
+    config: MailConfig,
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    card_paths: list[Path],
+    post=_post_resend,
+) -> None:
+    """Resend로 보낸다.
+
+    인라인 이미지(content_id)를 먼저 시도하고, API가 요청을 거부하면
+    첨부 전용으로 한 번만 다시 보낸다. 카드가 본문에 안 박히는 것보다
+    메일이 아예 안 가는 쪽이 나쁘기 때문이다.
+    """
+    for inline in (True, False):
+        payload = resend_payload(config, snapshots, commentary, issued, card_paths, inline)
+        response = post(config.resend_api_key, payload)
+
+        if response.status_code < 300:
+            how = "본문 인라인" if inline else "첨부"
+            log.info("Resend 발송 완료(%s) -> %s", how, ", ".join(config.recipients))
+            return
+
+        body = response.text[:500]
+        # 4xx는 요청 형식 문제다. 인라인 시도였다면 첨부 방식으로 물러선다.
+        if inline and 400 <= response.status_code < 500:
+            log.warning(
+                "Resend가 인라인 이미지 요청을 거부했습니다(%s: %s). 첨부 방식으로 재시도합니다.",
+                response.status_code,
+                body,
+            )
+            continue
+        raise SendError(f"Resend 발송 실패 ({response.status_code}): {body}")
+
+
+# --------------------------------------------------------------------------
+# Gmail SMTP
+# --------------------------------------------------------------------------
 
 def build_message(
     config: MailConfig,
@@ -98,15 +223,17 @@ def build_message(
     issued: dt.date,
     card_paths: list[Path],
 ) -> EmailMessage:
+    """SMTP용 MIME 메시지. 카드는 cid로 본문에 삽입한다."""
     message = EmailMessage()
     message["Subject"] = subject_line(commentary, issued)
-    message["From"] = f"{config.sender_name} <{config.user}>"
+    message["From"] = config.from_header
     message["To"] = ", ".join(config.recipients)
 
     message.set_content(plain_body(snapshots, commentary, issued))
 
     cids = [make_msgid(domain="fx.newsletter") for _ in card_paths]
-    message.add_alternative(html_body(snapshots, commentary, issued, cids), subtype="html")
+    srcs = [f"cid:{cid[1:-1]}" for cid in cids]
+    message.add_alternative(html_body(snapshots, commentary, issued, srcs), subtype="html")
 
     # add_alternative 뒤의 마지막 파트가 HTML 파트다. 여기에 이미지를 related로 붙인다.
     html_part = message.get_payload()[-1]
@@ -123,11 +250,7 @@ def build_message(
     return message
 
 
-def send(config: MailConfig, message: EmailMessage) -> None:
-    missing = config.validate()
-    if missing:
-        raise RuntimeError("메일 설정이 비어 있습니다: " + ", ".join(missing))
-
+def send_via_smtp(config: MailConfig, message: EmailMessage) -> None:
     if config.port == 587:
         with smtplib.SMTP(config.host, config.port, timeout=60) as server:
             server.starttls()
@@ -137,4 +260,24 @@ def send(config: MailConfig, message: EmailMessage) -> None:
         with smtplib.SMTP_SSL(config.host, config.port, timeout=60) as server:
             server.login(config.user, config.password)
             server.send_message(message)
-    log.info("메일 발송 완료 -> %s", ", ".join(config.recipients))
+    log.info("SMTP 발송 완료 -> %s", ", ".join(config.recipients))
+
+
+# --------------------------------------------------------------------------
+
+def send(
+    config: MailConfig,
+    snapshots: list[PairSnapshot],
+    commentary: Commentary,
+    issued: dt.date,
+    card_paths: list[Path],
+) -> None:
+    """설정된 수단으로 메일을 보낸다."""
+    missing = config.validate()
+    if missing:
+        raise SendError("메일 설정이 비어 있습니다: " + ", ".join(missing))
+
+    if config.provider == "resend":
+        send_via_resend(config, snapshots, commentary, issued, card_paths)
+    else:
+        send_via_smtp(config, build_message(config, snapshots, commentary, issued, card_paths))

--- a/tools/fx_newsletter/main.py
+++ b/tools/fx_newsletter/main.py
@@ -99,8 +99,8 @@ def run(args: argparse.Namespace) -> int:
         log.error("메일 설정 누락: %s", ", ".join(missing))
         return 2
 
-    message = mailer.build_message(config, snapshots, note, issued, card_paths)
-    mailer.send(config, message)
+    log.info("발송 수단: %s -> %s", config.provider, ", ".join(config.recipients))
+    mailer.send(config, snapshots, note, issued, card_paths)
     return 0
 
 

--- a/tools/fx_newsletter/tests/test_pipeline.py
+++ b/tools/fx_newsletter/tests/test_pipeline.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import datetime as dt
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 from fx_newsletter import cards, commentary, fetch, indicators, mailer
 from fx_newsletter.config import MailConfig
@@ -166,21 +168,35 @@ class RenderAndMailTest(unittest.TestCase):
             self.assertEqual(paths[0].name, "01-cover.png")
             self.assertEqual(paths[-1].name, "06-outlook.png")
 
-    def test_message_embeds_every_card_inline(self):
-        config = MailConfig(
+    def _smtp_config(self):
+        return MailConfig(
+            provider="smtp",
+            sender_name="주간 환율 브리핑",
+            sender_address="me@example.com",
+            recipients=("me@example.com",),
             host="smtp.gmail.com",
             port=465,
             user="me@example.com",
-            password="app pass word",
-            sender_name="주간 환율 브리핑",
-            recipients=("me@example.com",),
+            password="apppassword",
         )
+
+    def _resend_config(self):
+        return MailConfig(
+            provider="resend",
+            sender_name="주간 환율 브리핑",
+            sender_address="onboarding@resend.dev",
+            recipients=("me@example.com",),
+            resend_api_key="re_test",
+        )
+
+    def test_smtp_message_embeds_every_card_inline(self):
+        config = self._smtp_config()
         with tempfile.TemporaryDirectory() as tmp:
             paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
             message = mailer.build_message(config, self.snapshots, self.note, END, paths)
 
         self.assertIn(self.note.headline, message["Subject"])
-        self.assertEqual(message["To"], "me@example.com")
+        self.assertEqual(message["From"], "주간 환율 브리핑 <me@example.com>")
 
         html_parts = [p for p in message.walk() if p.get_content_type() == "text/html"]
         images = [p for p in message.walk() if p.get_content_type() == "image/png"]
@@ -189,15 +205,113 @@ class RenderAndMailTest(unittest.TestCase):
 
         html = html_parts[0].get_content()
         for part in images:
-            cid = part["Content-ID"].strip("<>")
-            self.assertIn(f"cid:{cid}", html)
+            self.assertIn(f"cid:{part['Content-ID'].strip('<>')}", html)
 
         plain = [p for p in message.walk() if p.get_content_type() == "text/plain"][0].get_content()
-        self.assertIn("주간 환율 브리핑", plain)
         for snapshot in self.snapshots:
             self.assertIn(snapshot.display_name, plain)
 
-    def test_mail_config_strips_app_password_spaces(self):
+    def test_resend_payload_shape(self):
+        config = self._resend_config()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            inline = mailer.resend_payload(config, self.snapshots, self.note, END, paths, True)
+            plain = mailer.resend_payload(config, self.snapshots, self.note, END, paths, False)
+
+        self.assertEqual(inline["to"], ["me@example.com"])
+        self.assertEqual(inline["from"], "주간 환율 브리핑 <onboarding@resend.dev>")
+        self.assertEqual(len(inline["attachments"]), len(paths))
+
+        # 인라인 요청은 content_id를 달고 HTML이 그것을 cid:로 참조한다.
+        for attachment in inline["attachments"]:
+            self.assertIn("content_id", attachment)
+            self.assertIn(f"cid:{attachment['content_id']}", inline["html"])
+            # content는 base64 문자열이어야 한다.
+            base64.b64decode(attachment["content"], validate=True)
+
+        # 첨부 전용 요청에는 content_id도 img 태그도 없다.
+        for attachment in plain["attachments"]:
+            self.assertNotIn("content_id", attachment)
+        self.assertNotIn("<img", plain["html"])
+        self.assertIn("첨부파일", plain["html"])
+
+    def test_resend_sends_inline_on_success(self):
+        config = self._resend_config()
+        calls = []
+
+        def fake_post(api_key, payload):
+            calls.append((api_key, payload))
+            return SimpleNamespace(status_code=200, text="{}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            mailer.send_via_resend(config, self.snapshots, self.note, END, paths, post=fake_post)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "re_test")
+        self.assertIn("content_id", calls[0][1]["attachments"][0])
+
+    def test_resend_falls_back_to_attachment_only_on_4xx(self):
+        """content_id를 모르는 API라도 메일은 나가야 한다."""
+        config = self._resend_config()
+        calls = []
+
+        def fake_post(api_key, payload):
+            calls.append(payload)
+            if "content_id" in payload["attachments"][0]:
+                return SimpleNamespace(status_code=422, text="unknown field content_id")
+            return SimpleNamespace(status_code=200, text="{}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            mailer.send_via_resend(config, self.snapshots, self.note, END, paths, post=fake_post)
+
+        self.assertEqual(len(calls), 2)
+        self.assertNotIn("content_id", calls[1]["attachments"][0])
+        self.assertNotIn("<img", calls[1]["html"])
+
+    def test_resend_raises_on_server_error(self):
+        config = self._resend_config()
+
+        def fake_post(api_key, payload):
+            return SimpleNamespace(status_code=500, text="boom")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            with self.assertRaises(mailer.SendError):
+                mailer.send_via_resend(config, self.snapshots, self.note, END, paths, post=fake_post)
+
+    def test_resend_does_not_retry_a_rejected_attachment_only_send(self):
+        """첨부 전용까지 거부당하면 조용히 성공한 척하지 않고 실패시킨다."""
+        config = self._resend_config()
+        calls = []
+
+        def fake_post(api_key, payload):
+            calls.append(payload)
+            return SimpleNamespace(status_code=422, text="nope")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = cards.render_all(self.snapshots, self.note, END, Path(tmp))
+            with self.assertRaises(mailer.SendError):
+                mailer.send_via_resend(config, self.snapshots, self.note, END, paths, post=fake_post)
+        self.assertEqual(len(calls), 2)
+
+    def test_env_picks_resend_when_key_present(self):
+        import os
+
+        os.environ.update({"RESEND_API_KEY": "re_x", "FX_MAIL_TO": "a@b.com"})
+        try:
+            config = MailConfig.from_env()
+        finally:
+            for key in ("RESEND_API_KEY", "FX_MAIL_TO"):
+                os.environ.pop(key, None)
+
+        self.assertEqual(config.provider, "resend")
+        self.assertEqual(config.sender_address, "onboarding@resend.dev")
+        self.assertEqual(config.recipients, ("a@b.com",))
+        self.assertEqual(config.validate(), [])
+
+    def test_env_falls_back_to_smtp_and_strips_app_password_spaces(self):
         import os
 
         os.environ.update(
@@ -208,14 +322,23 @@ class RenderAndMailTest(unittest.TestCase):
         finally:
             for key in ("FX_SMTP_USER", "FX_SMTP_PASSWORD"):
                 os.environ.pop(key, None)
+
+        self.assertEqual(config.provider, "smtp")
         self.assertEqual(config.password, "abcdefghijklmnop")
+        # 발신·수신 주소가 모두 SMTP 사용자로 채워진다.
+        self.assertEqual(config.sender_address, "a@b.com")
         self.assertEqual(config.recipients, ("a@b.com",))
         self.assertEqual(config.validate(), [])
 
-    def test_mail_config_reports_missing_fields(self):
-        config = MailConfig("h", 465, "", "", "n", ())
+    def test_validate_reports_missing_per_provider(self):
+        resend = MailConfig(provider="resend", sender_name="n", sender_address="", recipients=())
         self.assertEqual(
-            set(config.validate()), {"FX_SMTP_USER", "FX_SMTP_PASSWORD", "FX_MAIL_TO"}
+            set(resend.validate()), {"FX_MAIL_TO", "FX_MAIL_FROM", "RESEND_API_KEY"}
+        )
+        smtp = MailConfig(provider="smtp", sender_name="n", sender_address="", recipients=())
+        self.assertEqual(
+            set(smtp.validate()),
+            {"FX_MAIL_TO", "FX_MAIL_FROM", "FX_SMTP_USER", "FX_SMTP_PASSWORD"},
         )
 
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

뉴스레터 발송 수단으로 Resend를 추가하고 기본 경로로 삼았습니다. 기존 Gmail SMTP 경로는 폴백으로 남아 있습니다.

### 왜 바꿨나

지메일 앱 비밀번호는 **발송뿐 아니라 받은편지함 읽기 권한까지** 포함합니다. 자기 자신에게 주간 뉴스레터를 보내는 데 필요한 것보다 넓은 권한입니다. Resend API 키는 발송만 가능하므로, 같은 일을 더 좁은 권한으로 할 수 있습니다.

| | Resend (신규 기본값) | Gmail SMTP (기존) |
|---|---|---|
| 등록할 열쇠 | API 키 | 앱 비밀번호 |
| 열쇠의 권한 | 발송만 | 발송 + 받은편지함 읽기 |
| 추가 가입 | 필요 | 불필요 |

`RESEND_API_KEY`가 등록돼 있으면 Resend를, 없으면 기존 SMTP를 씁니다. 두 경로는 같은 HTML/텍스트 본문과 같은 카드 이미지를 공유합니다.

### 검증하지 못한 부분과 그에 대한 설계

개발 환경의 egress 정책이 `resend.com`을 차단해 **API 문서를 열지 못했습니다.** 따라서 첨부 객체가 인라인 이미지용 `content_id`를 지원하는지 확인할 수 없었습니다.

추정으로 확정하는 대신 실패해도 무해하도록 설계했습니다.

1. 먼저 `content_id`를 단 첨부 + HTML에서 `cid:` 참조로 보냅니다
2. API가 **4xx**로 거부하면 → `content_id`와 `<img>` 태그를 뺀 첨부 전용 페이로드로 **한 번만** 재시도합니다
3. **5xx**는 재시도하지 않고 실패시킵니다 (서버 문제를 형식 문제로 오인하지 않기 위해)

즉 최악의 경우에도 카드가 본문 인라인 대신 첨부로 도착할 뿐, 메일이 안 가지는 않습니다. 인라인이 안 될 경우를 대비해 HTML에 "카드 이미지는 첨부파일로 들어 있습니다" 안내와 통화별 요약 표가 항상 들어갑니다.

이 폴백 경로는 모킹으로 테스트했지만, `content_id`가 실제로 통하는지는 **첫 실제 발송에서 확인**됩니다. 로그에 `Resend 발송 완료(본문 인라인)` 또는 `(첨부)`로 어느 쪽이었는지 남습니다.

### 그 외 변경

- `MailConfig`가 발송 수단별로 검증합니다. `validate()`가 해당 경로에 필요한 환경 변수만 지적하므로, Resend를 쓰는데 `FX_SMTP_PASSWORD`가 없다고 불평하지 않습니다.
- `FX_MAIL_FROM`으로 발신 주소를 지정할 수 있습니다. 생략하면 `onboarding@resend.dev`입니다. 이 기본 주소는 Resend 계정 소유자 본인에게만 보낼 수 있으므로, 다른 수신자를 넣으려면 도메인 등록이 필요하다는 점을 README에 적었습니다.
- 워크플로 env에 `RESEND_API_KEY`, `FX_MAIL_FROM`을 추가했습니다.

### 테스트

23건 통과 (기존 17 + 6 신규). 추가된 것은 Resend 페이로드 형태(base64 인코딩, cid 참조 일치), 4xx 폴백 동작, 5xx 실패 처리, 첨부 전용까지 거부당했을 때 실패, 수단 자동 선택 두 갈래입니다.

```
Ran 23 tests in 6.035s
OK
```

## Context

관련 이슈 없음. #6에서 만든 파이프라인의 후속 변경입니다.

머지 후 Secrets에 `RESEND_API_KEY`와 `FX_MAIL_TO`를 등록하면 Resend 경로로 동작합니다. 기존 `FX_SMTP_*`를 등록해 둔 상태라면 `RESEND_API_KEY`를 추가하는 것만으로 Resend로 전환됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUCTgJeMCANirJRLFeRGV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUCTgJeMCANirJRLFeRGV2)_